### PR TITLE
Add required methods to test case mocks to allow compilation

### DIFF
--- a/core/src/test/java/com/zaubersoftware/gnip4j/http/ReconnectionTest.java
+++ b/core/src/test/java/com/zaubersoftware/gnip4j/http/ReconnectionTest.java
@@ -147,6 +147,13 @@ class MockRemoteResourceProvider implements RemoteResourceProvider {
     public void postResource(final URI uri, final Object resource) {
 
     }
+
+	@Override
+	public void deleteResource(URI uri, Object resource)
+			throws AuthenticationGnipException, TransportGnipException {
+		// TODO Auto-generated method stub
+		
+	}
 }
 
 class MockExecutorService implements ExecutorService {

--- a/core/src/test/java/com/zaubersoftware/gnip4j/jmx/JMXTest.java
+++ b/core/src/test/java/com/zaubersoftware/gnip4j/jmx/JMXTest.java
@@ -61,6 +61,13 @@ public final class JMXTest {
             public void postResource(final URI uri, final Object resource) {
                 
             }
+
+			@Override
+			public void deleteResource(URI uri, Object resource)
+					throws AuthenticationGnipException, TransportGnipException {
+				// TODO Auto-generated method stub
+				
+			}
         };
         final GnipFacade f = new DefaultGnipFacade(resources);
         final GnipStream stream = f.createStream("acme", "stream", observer);


### PR DESCRIPTION
I just added stub methods to the mocks so it will compile. they're not used at this time.
