### PR TITLE
Allow adding rules in batches

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/GnipFacade.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/GnipFacade.java
@@ -60,19 +60,38 @@ public interface GnipFacade {
     Rules getRules(String account, String streamName);
     
     /**
-     * Gnip provides a REST interface to the rules configured for each data collector.
-     * They can be modified either through this interface, or through the UI. These
-     * views are synchronized.
+     * Add a single rule from the Gnip stream
      * 
-     * Rules should be added one at a time, according to Gnip's documentation on best
-     * practices, so this method only lets you change one Rule. It can, of course, be
-     * called many times.
-     * 
-     @param account The account name for the power track API. (For example: acme)
+     * @param account The account name for the power track API. (For example: acme)
      * @param streamName the streamName
      * @param rule The Rule object to add to the tracker.
      */
     void addRule(String account, String streamName, Rule rule);
     
+    /**
+     * Add a collection of rules to the Gnip stream
+     * 
+     * @param account The account name for the power track API. (For example: acme)
+     * @param streamName the streamName
+     * @param rule The Rules object to add to the tracker
+     */
+    void addRules(String account, String streamName, Rules rules);
+    
+    /**
+     * Delete a single rule from the Gnip stream
+     * 
+     * @param account The account name for the power track API. (For example: acme)
+     * @param streamName the streamName
+     * @param rule The Rule object to add to the tracker.
+     */
     void deleteRule(String account, String streamName, Rule rule);
+    
+    /**
+     * Delete a collection of rules from the Gnip stream
+     * 
+     * @param account The account name for the power track API. (For example: acme)
+     * @param streamName the streamName
+     * @param rules The Rules object to add to the tracker.
+     */
+    void deleteRules(String account, String streamName, Rules rules);
 }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/DefaultGnipFacade.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/DefaultGnipFacade.java
@@ -168,19 +168,39 @@ public class DefaultGnipFacade implements GnipFacade {
         }
     }
 
+    /* (non-Javadoc)
+     * @see com.zaubersoftware.gnip4j.api.GnipFacade#addRule(java.lang.String, java.lang.String, com.zaubersoftware.gnip4j.api.model.Rule)
+     */
     @Override
     public final void addRule(final String account, final String streamName, final Rule rule) {
         Rules rules = new Rules();
         rules.getRules().add(rule);
-        
+        addRules(account, streamName, rules);
+    }
+    
+    /* (non-Javadoc)
+     * @see com.zaubersoftware.gnip4j.api.GnipFacade#addRules(java.lang.String, java.lang.String, com.zaubersoftware.gnip4j.api.model.Rules)
+     */
+    @Override
+    public final void addRules(final String account, final String streamName, final Rules rules) {
         facade.postResource(baseUriStrategy.createRulesUri(account, streamName), rules);
     }
     
+    /* (non-Javadoc)
+     * @see com.zaubersoftware.gnip4j.api.GnipFacade#deleteRule(java.lang.String, java.lang.String, com.zaubersoftware.gnip4j.api.model.Rule)
+     */
     @Override
     public final void deleteRule(final String account, final String streamName, final Rule rule) {
         Rules rules = new Rules();
         rules.getRules().add(rule);
-        
+        deleteRules(account, streamName, rules);
+    }
+    
+    /* (non-Javadoc)
+     * @see com.zaubersoftware.gnip4j.api.GnipFacade#deleteRules(java.lang.String, java.lang.String, com.zaubersoftware.gnip4j.api.model.Rules)
+     */
+    @Override
+    public final void deleteRules(final String account, final String streamName, final Rules rules) {
         facade.deleteResource(baseUriStrategy.createRulesUri(account, streamName), rules);
     }
 


### PR DESCRIPTION
The rules API is rate limited to 5 requests every 5 seconds and there
are situations where a large number of rules need to be modified beyond
this limit(E.g. during first application startup)

This is a minor change that adds an addRules and deleteRules method to
the GnipFacade that takes a Rules object to facilitate adding/deleting
rules in batches.
