### PR TITLE
Fixed incorrect validation of http request response status code

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/AbstractRemoteResourceProvider.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/AbstractRemoteResourceProvider.java
@@ -32,7 +32,7 @@ public abstract class AbstractRemoteResourceProvider implements RemoteResourcePr
     
     /** validate responses */
     public final void validateStatusLine(final URI uri, final int statusCode, final String reason) {
-        if (statusCode >= 200 || statusCode <= 299) {
+        if (statusCode >= 200 && statusCode <= 299) {
             // nothing to do
         } else if (statusCode == 401) {
             throw new AuthenticationGnipException(reason);


### PR DESCRIPTION
While using the library, I noticed it was not throwing any exceptions on invalid response status codes. There was an erroneous if-clause that would always validate to true, no matter the actual code - it's now fixed.

Regards,
Felipe Kurkowski
