### PR TITLE
Geometry, Size, and Sizes implements Serializable

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Geometry.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Geometry.java
@@ -15,6 +15,8 @@
  */
 package com.zaubersoftware.gnip4j.api.model;
 
+import java.io.Serializable;
+
 /**
  * TODO Descripcion de la clase. Los comentarios van en castellano.
  * 
@@ -22,7 +24,7 @@ package com.zaubersoftware.gnip4j.api.model;
  * @author Martin Silva
  * @since Feb 15, 2012
  */
-public interface Geometry {
+public interface Geometry extends Serializable {
     
     
     Geometries getType();

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Size.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Size.java
@@ -15,6 +15,8 @@
  */
 package com.zaubersoftware.gnip4j.api.model;
 
+import java.io.Serializable;
+
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
@@ -22,7 +24,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
  * 
  * <p>The following schema fragment specifies the expected content contained within this class.
  */
-public class Size {
+public class Size implements Serializable {
     
     @JsonProperty(value = "w")
     private int width;

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Sizes.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Sizes.java
@@ -15,12 +15,14 @@
  */
 package com.zaubersoftware.gnip4j.api.model;
 
+import java.io.Serializable;
+
 /**
  * <p>Java class for anonymous complex type.
  * 
  * <p>The following schema fragment specifies the expected content contained within this class.
  */
-public final class Sizes {
+public final class Sizes implements Serializable {
     
     private Size large;
     private Size medium;


### PR DESCRIPTION
I was having trouble serializing some `Activity` objects from Gnip and it turned out these classes do not implement `Serializable`.