### PR TITLE
Allow activities to be read off stream and processed as strings

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/BaseFeedProcessor.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/BaseFeedProcessor.java
@@ -17,7 +17,6 @@ package com.zaubersoftware.gnip4j.api.impl.formats;
 
 import java.util.concurrent.ExecutorService;
 
-import com.sun.org.apache.xerces.internal.impl.dv.ValidatedInfo;
 import com.zaubersoftware.gnip4j.api.GnipStream;
 import com.zaubersoftware.gnip4j.api.StreamNotification;
 
@@ -56,11 +55,11 @@ public abstract class BaseFeedProcessor<T> implements FeedProcessor {
     }
     
     /** handle an activity */
-    protected final void handle(final Object activity) {
+    protected final void handle(final T activity) {
         activityService.execute(new Runnable() {
             @Override
             public void run() {
-                notification.notify((T)activity, stream);
+                notification.notify(activity, stream);
             }
         });
     }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/StringFeedProcessor.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/StringFeedProcessor.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2011-2012 Zauber S.A. <http://www.zaubersoftware.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.impl.formats;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.text.ParseException;
+import java.util.concurrent.ExecutorService;
+
+import com.zaubersoftware.gnip4j.api.StreamNotification;
+import com.zaubersoftware.gnip4j.api.support.logging.LoggerFactory;
+import com.zaubersoftware.gnip4j.api.support.logging.spi.Logger;
+
+/**
+ * Feed processor that performs no parsing of each activity but instead
+ * passes along the activity as a {@link java.lang.String String} as it 
+ * was read off the stream.
+ */
+public class StringFeedProcessor extends BaseFeedProcessor<String> {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	public StringFeedProcessor(String streamName, ExecutorService activityService, StreamNotification<String> notification) {
+		super(streamName, activityService, notification);
+	}
+
+	@Override
+	public void process(InputStream is) throws IOException, ParseException {
+		BufferedReader rdr = new BufferedReader(new InputStreamReader(is));
+		
+        logger.debug("Starting to consume activity stream {} ...", streamName);
+        while (!Thread.interrupted()) {
+        	final String activity = rdr.readLine();
+        	handle(activity);
+        }
+	}
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/StringUnmarshaller.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/StringUnmarshaller.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2011-2012 Zauber S.A. <http://www.zaubersoftware.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.impl.formats;
+
+/**
+ * An unmarshaller that simply passes through the source value. Useful in 
+ * cases where no parsing is desired coming off the stream. For example, 
+ * pushing activities into a queue for asynchronous processing.  
+ */
+public class StringUnmarshaller implements Unmarshaller<String> {
+
+	@Override
+	public String unmarshall(String s) {
+		return s;
+	}
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/JRERemoteResourceProvider.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/JRERemoteResourceProvider.java
@@ -29,9 +29,8 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.map.ObjectMapper;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zaubersoftware.gnip4j.api.GnipAuthentication;
 import com.zaubersoftware.gnip4j.api.exception.AuthenticationGnipException;
 import com.zaubersoftware.gnip4j.api.exception.TransportGnipException;
@@ -135,7 +134,7 @@ public class JRERemoteResourceProvider extends AbstractRemoteResourceProvider {
             doConfiguration(uc);
             
             outStream = uc.getOutputStream();
-            outStream.write(mapper.writeValueAsString(resource).getBytes("utf-8"));
+            outStream.write(mapper.writeValueAsString(resource).getBytes("UTF-8"));
             
             if (huc != null) {
                 validateStatusLine(uri, huc.getResponseCode(), huc.getResponseMessage(),
@@ -182,7 +181,7 @@ public class JRERemoteResourceProvider extends AbstractRemoteResourceProvider {
             doConfiguration(uc);
             
             outStream = uc.getOutputStream();
-            outStream.write(new ObjectMapper().writeValueAsString(resource).getBytes());
+            outStream.write(new ObjectMapper().writeValueAsString(resource).getBytes("UTF-8"));
             
             if (huc != null) {
                 validateStatusLine(uri, huc.getResponseCode(), huc.getResponseMessage(), new DefaultErrorProvider(huc));


### PR DESCRIPTION
Useful in situations where parsing of activities is not desired when the stream is processed. For example, pushing activities into a message queue for asynchronous parsing and processing.