### PR TITLE
Support for PowerTrackV2 URIs and fix to BufferedReader against GZIPInputStream

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/StreamNotification.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/StreamNotification.java
@@ -57,4 +57,11 @@ public interface StreamNotification<T> {
      * @param waitTime The amount of time to be waited before trying to reconnect.
      */
     void notifyReConnectionAttempt(int attempt, long waitTime);
+
+    /**
+     * Notifies that we have successfully reconnected to gnip stream.
+     * 
+     * @param attempt The amount of re-connection attempts made before success.
+     */
+	void notifyReConnected(int i);
 }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/StreamNotificationAdapter.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/StreamNotificationAdapter.java
@@ -43,5 +43,10 @@ public abstract class StreamNotificationAdapter<T> implements StreamNotification
     public void notifyReConnectionAttempt(final int attempt, final long waitTime) {
         // Do nothing
     }
+    
+    @Override
+    public void notifyReConnected(final int attmepts){
+    	// Do nothing
+    }
 
 }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/DefaultGnipStream.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/DefaultGnipStream.java
@@ -289,7 +289,7 @@ public class DefaultGnipStream extends AbstractGnipStream {
                 logger.debug("{}: Re-connecting stream with Gnip: {}", streamName, streamURI);
                 is = getStreamInputStream();
                 logger.debug("{}: The re-connection has been successfully established", streamName);
-
+                notification.notifyReConnected(reConnectionAttempt.get());
                 reConnectionAttempt.set(0);
                 reConnectionWaitTime = INITIAL_RE_CONNECTION_WAIT_TIME;
                 stats.incrementNumberOfSuccessfulReconnections();

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/PowerTrackV2UriStrategy.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/PowerTrackV2UriStrategy.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2011-2012 Zauber S.A. <http://www.zaubersoftware.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.impl;
+
+import java.net.URI;
+
+import com.zaubersoftware.gnip4j.api.UriStrategy;
+
+/**
+ * Implementation of {@link UriStrategy} that creates {@link URI}s to connect
+ * to PowerTrack V2 Gnip endpoints which are different than those used in DefaultUriStrategy
+ * 
+ * As of 10/1/2015 PowerTrack V2 is in private beta.
+ * 
+ * https://stream-data-api.twitter.com/stream/powertrack/accounts/<account>/publishers/twitter/<stream>.json
+ * https://data-api.twitter.com/rules/powertrack/accounts/<account>/publishers/twitter/<stream>.json"
+ *
+ * <p>
+ * The base URI format for stream is {@link PowerTrackV2UriStrategy#BASE_GNIP_URI_FMT}
+ * <p>
+ *
+ * <p>
+ * The base URI format for rules is {@link PowerTrackV2UriStrategy#BASE_GNIP_RULES_URI_FMT}
+ * <p>
+ *
+ * @author mjmeyer
+ * @since 10/01/15
+ */
+public final class PowerTrackV2UriStrategy implements UriStrategy {
+    public static final String DEFAULT_STREAM_URL_BASE  = "https://stream-data-api.twitter.com";
+    public static final String DEFAULT_RULE_URL_BASE = "https://data-api.twitter.com";
+    public static final String PATH_GNIP_STREAM_URI =  "/stream/powertrack/accounts/%s/publishers/%s/%s.json";
+    public static final String PATH_GNIP_RULES_URI =  "/rules/powertrack/accounts/%s/publishers/%s/%s.json";
+
+    private String streamUrlBase = DEFAULT_STREAM_URL_BASE;
+    private String ruleUrlBase = DEFAULT_RULE_URL_BASE;
+
+    
+    private final String publisher;
+    
+    /** Creates the DefaultUriStrategy. */
+    public PowerTrackV2UriStrategy() {
+        this("twitter");
+    }
+    /** Creates the DefaultUriStrategy. */
+    public PowerTrackV2UriStrategy(final String publisher) {
+        if (publisher == null) {
+            throw new IllegalArgumentException("The publisher cannot be null or empty");
+        }
+        this.publisher = publisher;
+    }
+
+    @Override
+    public URI createStreamUri(final String account, final String streamName) {
+        if (account == null || account.trim().isEmpty()) {
+            throw new IllegalArgumentException("The account cannot be null or empty");
+        }
+        if (streamName == null || streamName.trim().isEmpty()) {
+            throw new IllegalArgumentException("The streamName cannot be null or empty");
+        }
+        
+        return URI.create(String.format(streamUrlBase + PATH_GNIP_STREAM_URI, account.trim(), publisher.trim(), streamName.trim()));
+    }
+
+    @Override
+    public URI createRulesUri(final String account, final String streamName) {
+        if (account == null || account.trim().isEmpty()) {
+            throw new IllegalArgumentException("The account cannot be null or empty");
+        }
+        if (streamName == null || streamName.trim().isEmpty()) {
+            throw new IllegalArgumentException("The streamName cannot be null or empty");
+        }
+        
+        return URI.create(String.format(ruleUrlBase + PATH_GNIP_RULES_URI, account.trim(), publisher.trim(), streamName.trim()));
+    }
+    
+    public final String getStreamUrlBase() {
+        return streamUrlBase;
+    }
+    
+    public final void setStreamUrlBase(final String streamUrlBase) {
+        if(streamUrlBase == null) {
+            throw new IllegalArgumentException("streamUrlBase can't be null");
+        }
+        this.streamUrlBase = streamUrlBase;
+    }
+    
+    public final String getRuleUrlBase() {
+        return ruleUrlBase;
+    }
+    
+    public final void setRuleUrlBase(final  String ruleUrlBase) {
+        if(ruleUrlBase == null) {
+            throw new IllegalArgumentException("streamUrlBase can't be null");
+        }
+        this.ruleUrlBase = ruleUrlBase;
+    }
+    
+    
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/ActivityUnmarshaller.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/ActivityUnmarshaller.java
@@ -27,7 +27,7 @@ import com.zaubersoftware.gnip4j.api.support.logging.LoggerFactory;
 import com.zaubersoftware.gnip4j.api.support.logging.spi.Logger;
 
 /**
- *  Unmarshalls Gnip's Activity
+ *  Unmarshalls Gnip's Activity from an Activity XML Stream
  * 
  * @author Juan F. Codagnone
  * @since Oct 3, 2013

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/BaseFeedProcessor.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/BaseFeedProcessor.java
@@ -55,11 +55,11 @@ public abstract class BaseFeedProcessor<T> implements FeedProcessor {
     }
     
     /** handle an activity */
-    protected final void handle(final Object activity) {
+    protected final void handle(final T activity) {
         activityService.execute(new Runnable() {
             @Override
             public void run() {
-                notification.notify((T)activity, stream);
+                notification.notify(activity, stream);
             }
         });
     }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/StringFeedProcessor.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/StringFeedProcessor.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2011-2012 Zauber S.A. <http://www.zaubersoftware.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.impl.formats;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.text.ParseException;
+import java.util.concurrent.ExecutorService;
+
+import com.zaubersoftware.gnip4j.api.StreamNotification;
+import com.zaubersoftware.gnip4j.api.support.logging.LoggerFactory;
+import com.zaubersoftware.gnip4j.api.support.logging.spi.Logger;
+
+/**
+ * Feed processor that performs no parsing of each activity but instead
+ * passes along the activity as a {@link java.lang.String String} as it 
+ * was read off the stream.
+ */
+public class StringFeedProcessor extends BaseFeedProcessor<String> {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	public StringFeedProcessor(String streamName, ExecutorService activityService, StreamNotification<String> notification) {
+		super(streamName, activityService, notification);
+	}
+
+	@Override
+	public void process(InputStream is) throws IOException, ParseException {
+		BufferedReader rdr = new BufferedReader(new InputStreamReader(is));
+		
+        logger.debug("Starting to consume activity stream {} ...", streamName);
+        while (!Thread.interrupted()) {
+        	final String activity = rdr.readLine();
+        	handle(activity);
+        }
+	}
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/StringUnmarshaller.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/StringUnmarshaller.java
@@ -13,20 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.zaubersoftware.gnip4j.api.model;
-
-import java.io.Serializable;
+package com.zaubersoftware.gnip4j.api.impl.formats;
 
 /**
- * TODO Descripcion de la clase. Los comentarios van en castellano.
- * 
- * 
- * @author Martin Silva
- * @since Feb 15, 2012
+ * An unmarshaller that simply passes through the source value. Useful in 
+ * cases where no parsing is desired coming off the stream. For example, 
+ * pushing activities into a queue for asynchronous processing.  
  */
-public interface Geometry extends Serializable {
-    
-    
-    Geometries getType();
-    
+public class StringUnmarshaller implements Unmarshaller<String> {
+
+	@Override
+	public String unmarshall(String s) {
+		return s;
+	}
 }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Activity.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Activity.java
@@ -65,6 +65,7 @@ public class Activity implements Serializable {
     private Object target;
     private String caption;
     private String comment;
+    private Info info;
     
     public final InReplyTo getInReplyTo() {
         return inReplyTo;
@@ -474,5 +475,13 @@ public class Activity implements Serializable {
     
     public void setComment(final String comment) {
         this.comment = comment;
+    }
+    
+    public Info getInfo() {
+        return info;
+    }
+
+    public void setInfo(final Info info) {
+        this.info = info;
     }
 }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Gnip.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Gnip.java
@@ -15,11 +15,11 @@
  */
 package com.zaubersoftware.gnip4j.api.model;
 
+import org.codehaus.jackson.annotate.JsonProperty;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.codehaus.jackson.annotate.JsonProperty;
 
 
 /**
@@ -59,15 +59,27 @@ public class Gnip implements Serializable {
         return matchingRules;
     }
 
+    public void setMatchingRules(List<MatchingRules> matchingRules) {
+        this.matchingRules = matchingRules;
+    }
+
     public final List<Url> getUrls() {
         if (urls  == null) {
             urls  = new ArrayList<Url>();
         }
         return urls;
     }
+
+    public void setUrls(List<Url> urls) {
+        this.urls = urls;
+    }
     
     public final Float getKloutScore() {
     	return kloutScore;
+    }
+
+    public void setKloutScore(Float kloutScore) {
+        this.kloutScore = kloutScore;
     }
     
     public final Long getFavoriteCount() {

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Info.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Info.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2011-2012 Zauber S.A. <http://www.zaubersoftware.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.model;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+/**
+ *
+ */
+public final class Info implements Serializable {
+    private static final long serialVersionUID = 1;
+    private String message;
+    private Date sent;
+    @JsonProperty(value = "activity_count")
+    private int activityCount;
+    @JsonProperty(value = "minutes_failed")
+    private List<Date> minutesFailed;
+
+    SimpleDateFormat dateFormatter;
+
+    public Info() {
+        //2013-02-27T22:15:50+00:00
+        this.dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'kk:mm:ssXXX");
+    }
+
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Date getSent() {
+        return sent;
+    }
+
+    public void setSent(Date sent) {
+        this.sent = sent;
+    }
+
+    public int getActivityCount() {
+        return activityCount;
+    }
+
+    public void setActivityCount(int activityCount) {
+        this.activityCount = activityCount;
+    }
+
+    public List<Date> getMinutesFailed() {
+        return minutesFailed;
+    }
+
+    public void setMinutesFailed(List<Date> minutesFailed) {
+        this.minutesFailed = minutesFailed;
+    }
+
+    public String toString() {
+        StringBuilder s = new StringBuilder("Info[");
+        s.append("message:").append(this.message);
+        s.append(", sent:").append(this.dateFormatter.format(this.sent));
+        s.append(", activity_count:").append(this.activityCount);
+        int size = 0;
+        if (this.minutesFailed != null && (size = this.minutesFailed.size()) > 0) {
+            s.append(", minutes_failed: [");
+            int i = 0;
+            for (Date minute_failed : this.minutesFailed) {
+                s.append(this.dateFormatter.format(minute_failed));
+                i++;
+                if (i < size) {
+                    s.append(", ");
+                }
+            }
+            s.append("]");
+        }
+        s.append("]");
+        return s.toString();
+    }
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Size.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Size.java
@@ -15,6 +15,8 @@
  */
 package com.zaubersoftware.gnip4j.api.model;
 
+import java.io.Serializable;
+
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
@@ -22,7 +24,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
  * 
  * <p>The following schema fragment specifies the expected content contained within this class.
  */
-public class Size {
+public class Size implements Serializable {
     
     @JsonProperty(value = "w")
     private int width;

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Sizes.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Sizes.java
@@ -15,12 +15,14 @@
  */
 package com.zaubersoftware.gnip4j.api.model;
 
+import java.io.Serializable;
+
 /**
  * <p>Java class for anonymous complex type.
  * 
  * <p>The following schema fragment specifies the expected content contained within this class.
  */
-public final class Sizes {
+public final class Sizes implements Serializable {
     
     private Size large;
     private Size medium;

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/JRERemoteResourceProvider.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/JRERemoteResourceProvider.java
@@ -103,7 +103,7 @@ public class JRERemoteResourceProvider extends AbstractRemoteResourceProvider {
     static InputStream getRealInputStream(final URLConnection uc, InputStream is) throws IOException {
         final String encoding = uc.getContentEncoding();
         if (encoding != null && encoding.equalsIgnoreCase("gzip")) {
-            is = new GZIPInputStream(is);
+            is = new StreamingGZIPInputStream(is);
         } else if (encoding != null && encoding.equalsIgnoreCase("deflate")) {
             is = new InflaterInputStream(is, new Inflater(true));
         }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/StreamingGZIPInputStream.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/StreamingGZIPInputStream.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2011-2012 Zauber S.A. <http://www.zaubersoftware.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.zaubersoftware.gnip4j.api.support.http;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
+
+public class StreamingGZIPInputStream extends GZIPInputStream {
+ 
+    private final InputStream wrapped;
+    public StreamingGZIPInputStream(InputStream is) throws IOException {
+      super(is);
+      wrapped = is;
+    }
+ 
+    /**
+     * GZIPInputStream assumes all data is present when reading/checking available bytes
+     * This is not true for streaming use cases like connections to PowerTrack streams.
+     * 
+     * 
+     * We will wrap the GZIPInputStream and use the underlying InputStream to tell us
+     * how much data is available.
+     * 
+     * Without this wrapping, was seeing that the BufferedReader in ByLineFeedProcessor
+     * was never geeing lines to read.
+     * 
+     * Warning dont rely on this method to return the actual number
+     * of bytes that could be read without blocking.
+     *
+     * @return - whatever the wrapped InputStream returns
+     * @exception  IOException  if an I/O error occurs.
+     */
+    
+    public int available() throws IOException {
+      return wrapped.available();
+    }
+}

--- a/core/src/test/java/com/zaubersoftware/gnip4j/http/JSONDeserializationTest.java
+++ b/core/src/test/java/com/zaubersoftware/gnip4j/http/JSONDeserializationTest.java
@@ -24,8 +24,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectOutputStream;
 import java.util.Arrays;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 
+import com.zaubersoftware.gnip4j.api.model.Info;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -56,6 +59,54 @@ public final class JSONDeserializationTest {
     @Before
     public void setUp() throws Exception {
         mapper = JsonActivityFeedProcessor.getObjectMapper();
+    }
+
+
+    @Test
+    public void testReplayCompletedMessage() throws Exception {
+        final InputStream is = getClass().getClassLoader().getResourceAsStream(
+                "com/zaubersoftware/gnip4j/payload/replay-request-completed.json");
+        try {
+            JsonParser parser = mapper.getJsonFactory().createJsonParser(is);
+            Activity activity = parser.readValueAs(Activity.class);
+            Info info = activity.getInfo();
+            assertNotNull(info);
+            assertEquals("message content", "Replay Request Completed", info.getMessage());
+            assertEquals("activity count", 8874, info.getActivityCount());
+            assertTrue("info date",
+                    info.getSent()
+                            .equals(new SimpleDateFormat("yyyy-MM-dd'T'kk:mm:ssXXX")
+                                    .parse("2013-02-27T22:15:50+00:00")));
+        } finally {
+            if (is != null) {
+                is.close();
+            }
+        }
+    }
+
+    @Test
+    public void testReplayCompletedWithErrorsMessage() throws Exception {
+        final InputStream is = getClass().getClassLoader().getResourceAsStream(
+                "com/zaubersoftware/gnip4j/payload/replay-request-completed-with-errors.json");
+        try {
+            JsonParser parser = mapper.getJsonFactory().createJsonParser(is);
+            Activity activity = parser.readValueAs(Activity.class);
+            Info info = activity.getInfo();
+            assertNotNull(info);
+            assertEquals("message content", "Replay Request Completed with Errors", info.getMessage());
+            assertEquals("activity count", 56333, info.getActivityCount());
+            assertTrue("info date",
+                    info.getSent()
+                            .equals(new SimpleDateFormat("yyyy-MM-dd'T'kk:mm:ssXXX")
+                                    .parse("2013-02-27T16:00:02+00:00")));
+            List<Date> minutesFailed = info.getMinutesFailed();
+            assertNotNull(minutesFailed);
+            assertEquals("size of minutesFailed", 2, minutesFailed.size());
+        } finally {
+            if (is != null) {
+                is.close();
+            }
+        }
     }
 
     /** test a complete unmarshal from the json */

--- a/core/src/test/java/com/zaubersoftware/gnip4j/http/ReconnectionTest.java
+++ b/core/src/test/java/com/zaubersoftware/gnip4j/http/ReconnectionTest.java
@@ -97,6 +97,13 @@ public final class ReconnectionTest {
                     stream.close();
                 }
             }
+
+			@Override
+			public void notifyReConnected(int attempt) {
+				out.append(String.format(
+                        "Connection attempt %d succeeded\n", attempt));
+				
+			}
         };
         final JsonActivityFeedProcessor processor = new JsonActivityFeedProcessor("stream", Executors.newSingleThreadExecutor(), n);
         processor.setStream(stream);

--- a/core/src/test/resources/com/zaubersoftware/gnip4j/payload/replay-request-completed-with-errors.json
+++ b/core/src/test/resources/com/zaubersoftware/gnip4j/payload/replay-request-completed-with-errors.json
@@ -1,0 +1,11 @@
+{
+  "info": {
+    "message": "Replay Request Completed with Errors",
+    "sent": "2013-02-27T16:00:02+00:00",
+    "activity_count": 56333,
+    "minutes_failed": [
+      "2013-02-20T00:05:00+00:00",
+      "2013-02-20T00:06:00+00:00"
+    ]
+  }
+}

--- a/core/src/test/resources/com/zaubersoftware/gnip4j/payload/replay-request-completed.json
+++ b/core/src/test/resources/com/zaubersoftware/gnip4j/payload/replay-request-completed.json
@@ -1,0 +1,7 @@
+{
+  "info": {
+    "message": "Replay Request Completed",
+    "sent": "2013-02-27T22:15:50+00:00",
+    "activity_count": 8874
+  }
+}


### PR DESCRIPTION
1) Fixed issue with BufferedReader in ByLineFeedProcessor never getting lines due to how GZIPInputStream.available() works with streaming content such as gnip streams. Wrapped GZIPInputStream and using origin InputStream as source of available bytes.

2) Implementation of UriStrategy that creates URIs that work against PowerTrack V2 Gnip endpoints which are different than those used in DefaultUriStrategy/ older Gnip PowerTrack.
As of 10/1/2015 PowerTrack V2 is in private beta.
New endpoints are in the shape:
https://stream-data-api.twitter.com/stream/powertrack/accounts/<account>/publishers/twitter/<stream>.json
https://data-api.twitter.com/rules/powertrack/accounts/<account>/publishers/twitter/<stream>.json"