### PR TITLE
Fixes issue with BufferedReader in ByLineFeedProcessor never getting lines

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/JRERemoteResourceProvider.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/JRERemoteResourceProvider.java
@@ -103,7 +103,7 @@ public class JRERemoteResourceProvider extends AbstractRemoteResourceProvider {
     static InputStream getRealInputStream(final URLConnection uc, InputStream is) throws IOException {
         final String encoding = uc.getContentEncoding();
         if (encoding != null && encoding.equalsIgnoreCase("gzip")) {
-            is = new GZIPInputStream(is);
+            is = new StreamingGZIPInputStream(is);
         } else if (encoding != null && encoding.equalsIgnoreCase("deflate")) {
             is = new InflaterInputStream(is, new Inflater(true));
         }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/StreamingGZIPInputStream.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/StreamingGZIPInputStream.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2011-2012 Zauber S.A. <http://www.zaubersoftware.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.zaubersoftware.gnip4j.api.support.http;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
+
+public class StreamingGZIPInputStream extends GZIPInputStream {
+ 
+    private final InputStream wrapped;
+    public StreamingGZIPInputStream(InputStream is) throws IOException {
+      super(is);
+      wrapped = is;
+    }
+ 
+    /**
+     * GZIPInputStream assumes all data is present when reading/checking available bytes
+     * This is not true for streaming use cases like connections to PowerTrack streams.
+     * 
+     * 
+     * We will wrap the GZIPInputStream and use the underlying InputStream to tell us
+     * how much data is available.
+     * 
+     * Without this wrapping, was seeing that the BufferedReader in ByLineFeedProcessor
+     * was never geeing lines to read.
+     * 
+     * Warning dont rely on this method to return the actual number
+     * of bytes that could be read without blocking.
+     *
+     * @return - whatever the wrapped InputStream returns
+     * @exception  IOException  if an I/O error occurs.
+     */
+    
+    public int available() throws IOException {
+      return wrapped.available();
+    }
+}


### PR DESCRIPTION
… due to how GZIPInputStream.available() works with streaming content such as gnip streams. Wrapped GZIPInputStream and use origin InputStream as source of available bytes.

Using the unwrapped GZIPInputStream may have worked with powertrack version prior to V2. As of Powertrack V2 which is currently in private beta, wrapping of the stream with an impl that gives good availableBytes value is necessary.