### PR TITLE
Improved generics usage with PowerTrackStreamBuilder…

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/GnipFacade.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/GnipFacade.java
@@ -29,8 +29,9 @@ public interface GnipFacade {
     /** Let you create an Enterprices Data Collector Stream */
     EDCStreamBuilder createEnterpriceDataCollectorStream();
     
-    /** Let you create a Powertrack Stream */
-    PowertrackStreamBuilder createPowertrackStream();
+    /** Let you create a Powertrack Stream 
+     * @param <T>*/
+    <T> PowertrackStreamBuilder<T> createPowertrackStream();
     
     /////////////////////////////////////////////////////////////////////////////////////////////////////////
     /**

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/PowertrackStreamBuilder.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/PowertrackStreamBuilder.java
@@ -25,14 +25,15 @@ import com.zaubersoftware.gnip4j.api.model.Activity;
  * 
  * 
  * @author Juan F. Codagnone
+ * @param <T>
  * @since Oct 3, 2013
  */
-public abstract class PowertrackStreamBuilder {
+public abstract class PowertrackStreamBuilder<T> {
     protected String type;
     private int streamDefaultWorkers = Runtime.getRuntime().availableProcessors();
     protected ExecutorService executorService = Executors.newFixedThreadPool(streamDefaultWorkers);
     protected String account;
-    protected StreamNotification<Activity> observer;
+    protected StreamNotification<T> observer;
     
     /**  if your EDC URL starts with http://acme.gnip.com  then this value is acme*/
     public final PowertrackStreamBuilder withAccount(final String account) {
@@ -40,7 +41,7 @@ public abstract class PowertrackStreamBuilder {
         return this;
     }
     
-    public final PowertrackStreamBuilder withObserver(final StreamNotification observer) {
+    public final PowertrackStreamBuilder withObserver(final StreamNotification<T> observer) {
         this.observer = observer;
         return this;
     }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/DefaultGnipFacade.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/DefaultGnipFacade.java
@@ -78,7 +78,7 @@ public class DefaultGnipFacade implements GnipFacade {
     }
 
     @Override
-    public final PowertrackStreamBuilder createPowertrackStream() {
+    public PowertrackStreamBuilder createPowertrackStream() {
         return new PowertrackStreamBuilder() {
             @Override
             protected GnipStream buildStream() {


### PR DESCRIPTION
 to make it easier for a client app to make use of StringFeedProcessor by simply extending DefaultGnipFacade with overriden createPowertrackStream() as in:

public class RawJsonGnipFacade extends DefaultGnipFacade {

	 public RawJsonGnipFacade(final RemoteResourceProvider facade, final UriStrategy baseUriStrategy) {
	        super(facade,  baseUriStrategy);
	 }

	@Override
	public final PowertrackStreamBuilder createPowertrackStream() {
		return new PowertrackStreamBuilder<String>() {
			@Override
			protected GnipStream buildStream() {
				final String streamName = String.format("powertrack-%s-%s", this.account, this.type);
				final FeedProcessor processor = new StringFeedProcessor(streamName,
																		executorService,
																		this.observer);
				final GnipStream stream = createStream(	this.account,
														type, this.observer,
														this.executorService,
														new ActivityUnmarshaller(streamName), processor);
				processor.setStream(stream);
				return stream;
			}
		};
	}
}