### PR TITLE
Fixed issue with StringFeedProcessor sending emtpy activites to observer

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/StringFeedProcessor.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/StringFeedProcessor.java
@@ -45,7 +45,10 @@ public class StringFeedProcessor extends BaseFeedProcessor<String> {
         logger.debug("Starting to consume activity stream {} ...", streamName);
         while (!Thread.interrupted()) {
         	final String activity = rdr.readLine();
-        	handle(activity);
+        	// lines with zero length are keep-alive msgs from stream
+        	if (activity.length() > 0){
+        		handle(activity);
+        	}
         }
 	}
 }


### PR DESCRIPTION
Found that PowerTrack V2 streams are sending CRLF keep alive lines every 30 secs or so which leak through to StringFeedProcessor who was sending them along as activities to the observer. Zero length lines are no longer sent to observer.

Not sure if V1 streams send same keep-alives but this shouldnt break things if they dont.