### PR TITLE
Fix issue with StreamStats.transferedActivities getting incorrectly i…

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/DefaultGnipStream.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/DefaultGnipStream.java
@@ -228,7 +228,7 @@ public class DefaultGnipStream extends AbstractGnipStream {
                             reconnect();
                         }
                         if(is != null) {
-                            processor.process(is);
+                            processor.process(is,stats);
                             logger.debug("{}: The activity stream is no longer being consumed.", streamName);
                         }
                     } catch(final IOException e) {

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/ByLineFeedProcessor.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/ByLineFeedProcessor.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 
 import com.zaubersoftware.gnip4j.api.GnipStream;
 import com.zaubersoftware.gnip4j.api.StreamNotification;
+import com.zaubersoftware.gnip4j.api.stats.ModifiableStreamStats;
 
 /**
  * Custom feed processor   
@@ -43,7 +44,7 @@ public class ByLineFeedProcessor<T> extends BaseFeedProcessor<T> {
     }
     
     @Override
-    public final void process(final InputStream is) throws IOException, ParseException {
+    public final void process(final InputStream is, final ModifiableStreamStats stats) throws IOException, ParseException {
         // hack
         final BufferedReader reader = new BufferedReader(new InputStreamReader(is, "utf-8"));
         String s = null;
@@ -51,6 +52,9 @@ public class ByLineFeedProcessor<T> extends BaseFeedProcessor<T> {
         while ((s = reader.readLine()) != null) {
             if(!s.isEmpty()) {
                 handle(unmarshaller.unmarshall(s));
+                if (stats != null){
+                	stats.incrementTransferedActivities();
+                }
             }
             if(Thread.interrupted()) {
                 break;

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/FeedProcessor.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/FeedProcessor.java
@@ -20,12 +20,13 @@ import java.io.InputStream;
 import java.text.ParseException;
 
 import com.zaubersoftware.gnip4j.api.GnipStream;
+import com.zaubersoftware.gnip4j.api.stats.ModifiableStreamStats;
 
 
 /** process the content of a feed */
 public interface FeedProcessor {
     /** process the content of a gnip feed. must be interrumplible */
-    void process(final InputStream is) throws IOException, ParseException;
+    void process(final InputStream is, final ModifiableStreamStats stats) throws IOException, ParseException;
     
     void setStream(final GnipStream stream);
 }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/JsonActivityFeedProcessor.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/JsonActivityFeedProcessor.java
@@ -31,6 +31,7 @@ import com.zaubersoftware.gnip4j.api.model.Activity;
 import com.zaubersoftware.gnip4j.api.model.Geo;
 import com.zaubersoftware.gnip4j.api.model.GeoDeserializer;
 import com.zaubersoftware.gnip4j.api.model.GeoSerializer;
+import com.zaubersoftware.gnip4j.api.stats.ModifiableStreamStats;
 import com.zaubersoftware.gnip4j.api.support.logging.LoggerFactory;
 import com.zaubersoftware.gnip4j.api.support.logging.spi.Logger;
 
@@ -60,14 +61,17 @@ public class JsonActivityFeedProcessor extends BaseFeedProcessor {
     }
     
     @Override
-    public final void process(final InputStream is) throws IOException {
+    public final void process(final InputStream is, final ModifiableStreamStats stats) throws IOException {
         final JsonParser parser =  JsonActivityFeedProcessor
                 .getObjectMapper().getJsonFactory().createJsonParser(is);
 
-        logger.debug("Starting to consume activity stream {} ...", streamName);
+        logger.info("Starting to consume activity stream {} ...", streamName);
         while(!Thread.interrupted()) {
             final Activity activity = parser.readValueAs(Activity.class);
             handle(activity);
+            if (activity != null && stats != null){
+            	stats.incrementTransferedActivities();
+            }
         }
     }
 }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/StringFeedProcessor.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/StringFeedProcessor.java
@@ -23,6 +23,7 @@ import java.text.ParseException;
 import java.util.concurrent.ExecutorService;
 
 import com.zaubersoftware.gnip4j.api.StreamNotification;
+import com.zaubersoftware.gnip4j.api.stats.ModifiableStreamStats;
 import com.zaubersoftware.gnip4j.api.support.logging.LoggerFactory;
 import com.zaubersoftware.gnip4j.api.support.logging.spi.Logger;
 
@@ -39,7 +40,7 @@ public class StringFeedProcessor extends BaseFeedProcessor<String> {
 	}
 
 	@Override
-	public void process(InputStream is) throws IOException, ParseException {
+	public void process(InputStream is, final ModifiableStreamStats stats) throws IOException, ParseException {
 		BufferedReader rdr = new BufferedReader(new InputStreamReader(is));
 		
         logger.debug("Starting to consume activity stream {} ...", streamName);
@@ -48,6 +49,9 @@ public class StringFeedProcessor extends BaseFeedProcessor<String> {
         	// lines with zero length are keep-alive msgs from stream
         	if (activity.length() > 0){
         		handle(activity);
+        		if (stats != null){
+        			stats.incrementTransferedActivities();
+        		}
         	}
         }
 	}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/XMLActivityStreamFeedProcessor.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/XMLActivityStreamFeedProcessor.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.regex.Pattern;
 
 import com.zaubersoftware.gnip4j.api.StreamNotification;
+import com.zaubersoftware.gnip4j.api.stats.ModifiableStreamStats;
 
 /**
  * <p>
@@ -85,7 +86,7 @@ public class XMLActivityStreamFeedProcessor<T> extends BaseFeedProcessor<T> {
     }
 
     @Override
-    public final void process(final InputStream is) throws IOException, ParseException {
+    public final void process(final InputStream is, final ModifiableStreamStats stats) throws IOException, ParseException {
         // hack
         final BufferedReader reader = new BufferedReader(new InputStreamReader(is, "utf-8"));
         String s = null;
@@ -102,6 +103,9 @@ public class XMLActivityStreamFeedProcessor<T> extends BaseFeedProcessor<T> {
                 handle(unmarshaller.unmarshall(sb.toString()));
             } else {
                 sb.append(s);
+            }
+            if (! s.isEmpty() && stats != null){
+            	stats.incrementTransferedActivities();
             }
         }
     }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/stats/StreamStatsInputStream.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/stats/StreamStatsInputStream.java
@@ -37,9 +37,11 @@ public class StreamStatsInputStream extends TeeInputStream {
             public void write(final int b) throws IOException {
                 stats.incrementTransferedBytes();
                 
-                if (b == '\n') {
+                // new line not sufficient to count as activity rcvd since stream
+                // sends CRLF every 30 secs or so to keep-alive
+                /*if (b == '\n') {
                     stats.incrementTransferedActivities();
-                }
+                }*/
             }
         });
     }

--- a/core/src/test/java/com/zaubersoftware/gnip4j/api/impl/XMLActivityStreamFeedProcessorTest.java
+++ b/core/src/test/java/com/zaubersoftware/gnip4j/api/impl/XMLActivityStreamFeedProcessorTest.java
@@ -81,7 +81,7 @@ public class XMLActivityStreamFeedProcessorTest {
                             }
                         }
                     }, new ActivityUnmarshaller("hola"));
-            p.process(is);
+            p.process(is, null);
             assertEquals(23, i.get());
         } finally {
             IOUtils.closeQuietly(is);


### PR DESCRIPTION
…ncremented with each line being read from stream, inclusive of CRLF keep-alive lines. Without this fix and using Powertrack V2 streams the CRLF keep-alives coming in each 30 seconds or so get counted as a new activity.
(rebased from: https://github.com/zauberlabs/gnip4j/pull/37/files)