### PR TITLE
Support for PowertrackV2 API changes to url pattern and http method u…

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/UriStrategy.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/UriStrategy.java
@@ -25,9 +25,18 @@ import java.net.URI;
  */
 public interface UriStrategy {
 
-    /** Generates a {@link URI} to connect against a Gnip endpoint to consume the activity stream. */
+    String HTTP_DELETE = "DELETE";
+    String HTTP_POST = "POST";
+
+	/** Generates a {@link URI} to connect against a Gnip endpoint to consume the activity stream. */
     URI createStreamUri(String account, String streamName);
 
     /** Generates a {@link URI} to connect against a Gnip endpoint to get/modify rules. */
     URI createRulesUri(String account, String streamName);
+
+    /** Generates a {@link URI} to connect against a Gnip endpoint to delete rules. */
+	URI createRulesDeleteUri(String account, String streamName);
+
+	/** Informs the {@link GnipFacade} which http verb/method to use for rule deletion. Powertrack V2 API uses POST. V1 uses DELETE. */
+	String getHttpMethodForRulesDelete();
 }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/DefaultGnipFacade.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/DefaultGnipFacade.java
@@ -210,7 +210,11 @@ public class DefaultGnipFacade implements GnipFacade {
     
     @Override
     public final void deleteRules(final String account, final String streamName, final Rules rules) {
-        facade.deleteResource(baseUriStrategy.createRulesUri(account, streamName), rules);
+    	if (baseUriStrategy.getHttpMethodForRulesDelete().equals(UriStrategy.HTTP_POST)){
+    		facade.postResource(baseUriStrategy.createRulesDeleteUri(account, streamName), rules);
+    	} else {
+    		facade.deleteResource(baseUriStrategy.createRulesDeleteUri(account, streamName), rules);
+    	}
     }
 
     public final boolean isUseJMX() {

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/DefaultUriStrategy.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/DefaultUriStrategy.java
@@ -83,6 +83,16 @@ public final class DefaultUriStrategy implements UriStrategy {
         return URI.create(String.format(ruleUrlBase + PATH_GNIP_RULES_URI, account.trim(), publisher.trim(), streamName.trim()));
     }
     
+    @Override
+    public URI createRulesDeleteUri(final String account, final String streamName) {
+    	return createRulesUri(account, streamName);
+    }
+    
+    @Override
+	public String getHttpMethodForRulesDelete() {
+		return UriStrategy.HTTP_DELETE;
+	}
+    
     public final String getStreamUrlBase() {
         return streamUrlBase;
     }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/EnterpriseDataCollectorUriStrategy.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/EnterpriseDataCollectorUriStrategy.java
@@ -56,5 +56,15 @@ public final class EnterpriseDataCollectorUriStrategy implements UriStrategy {
         
         return URI.create(String.format(RULES_URI, account.trim(), streamName.trim()));
     }
+    
+    @Override
+    public URI createRulesDeleteUri(final String account, final String streamName) {
+    	return createRulesUri(account, streamName);
+    }
+    
+    @Override
+	public String getHttpMethodForRulesDelete() {
+		return UriStrategy.HTTP_DELETE;
+	}
 
 }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/PowerTrackV2UriStrategy.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/PowerTrackV2UriStrategy.java
@@ -77,14 +77,28 @@ public final class PowerTrackV2UriStrategy implements UriStrategy {
 
     @Override
     public URI createRulesUri(final String account, final String streamName) {
-        if (account == null || account.trim().isEmpty()) {
-            throw new IllegalArgumentException("The account cannot be null or empty");
-        }
-        if (streamName == null || streamName.trim().isEmpty()) {
-            throw new IllegalArgumentException("The streamName cannot be null or empty");
-        }
-        
-        return URI.create(String.format(ruleUrlBase + PATH_GNIP_RULES_URI, account.trim(), publisher.trim(), streamName.trim()));
+        return URI.create(createRulesBaseUrl(account, streamName));
+    }
+    
+    @Override
+    public URI createRulesDeleteUri(final String account, final String streamName) {
+    	 return URI.create(createRulesBaseUrl(account, streamName) + "?_method=delete");
+    }
+    
+    @Override
+	public String getHttpMethodForRulesDelete() {
+		return UriStrategy.HTTP_POST;
+	}
+    
+    private String createRulesBaseUrl(final String account, final String streamName) {
+    	 if (account == null || account.trim().isEmpty()) {
+             throw new IllegalArgumentException("The account cannot be null or empty");
+         }
+         if (streamName == null || streamName.trim().isEmpty()) {
+             throw new IllegalArgumentException("The streamName cannot be null or empty");
+         }
+         
+         return String.format(ruleUrlBase + PATH_GNIP_RULES_URI, account.trim(), publisher.trim(), streamName.trim());
     }
     
     public final String getStreamUrlBase() {

--- a/core/src/test/java/com/zaubersoftware/gnip4j/http/LocalhostTestDriver.java
+++ b/core/src/test/java/com/zaubersoftware/gnip4j/http/LocalhostTestDriver.java
@@ -52,6 +52,16 @@ public final class LocalhostTestDriver {
                 public URI createRulesUri(final String domain, final String streamName) {
                     return null;
                 }
+                
+                @Override
+                public URI createRulesDeleteUri(final String domain, final String streamName) {
+                    return null;
+                }
+                
+                @Override
+            	public String getHttpMethodForRulesDelete() {
+            		return UriStrategy.HTTP_DELETE;
+            	}
             };
             final JRERemoteResourceProvider resourceProvider = new JRERemoteResourceProvider(
                     new ImmutableGnipAuthentication("foo", "bar"));


### PR DESCRIPTION
…sed for rule deletion.

PowertrackV1 did:
DELETE /rules/powertrack/accounts/{account}/publishers/twitter/{stream}.json

PowertrackV2 expects:
POST /rules/powertrack/accounts/{account}/publishers/twitter/{stream}.json?_method=delete

(rebased from https://github.com/zauberlabs/gnip4j/pull/38)