### PR TITLE
Added detail to errors mapping

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/exception/OffendingRule.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/exception/OffendingRule.java
@@ -15,6 +15,8 @@
  */
 package com.zaubersoftware.gnip4j.api.exception;
 
+import org.codehaus.jackson.annotate.JsonProperty;
+
 import com.zaubersoftware.gnip4j.api.model.Rule;
 
 /**
@@ -35,7 +37,8 @@ public class OffendingRule {
    * @throws IllegalArgumentException
    *           if any of the parameters is empty or null.
    */
-  public OffendingRule(final Rule offendingRule, final String errorMessage) {
+    public OffendingRule(@JsonProperty("rule") final Rule offendingRule,
+            @JsonProperty("message") final String errorMessage) {
     super();
 
     if (offendingRule == null) {

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/JRERemoteResourceProvider.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/JRERemoteResourceProvider.java
@@ -25,15 +25,18 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URLConnection;
-import java.util.zip.GZIPInputStream;
+import java.util.List;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.annotate.JsonDeserialize;
 
 import com.zaubersoftware.gnip4j.api.GnipAuthentication;
 import com.zaubersoftware.gnip4j.api.exception.AuthenticationGnipException;
+import com.zaubersoftware.gnip4j.api.exception.OffendingRule;
 import com.zaubersoftware.gnip4j.api.exception.TransportGnipException;
 import com.zaubersoftware.gnip4j.api.impl.ErrorCodes;
 import com.zaubersoftware.gnip4j.api.support.base64.Base64PasswordEncoderFactory;
@@ -259,9 +262,13 @@ class Errors {
     }
     
 }
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 class Error {
     private String message;
+
+    @JsonProperty("detail")
+    private List<OffendingRule> rules;
 
     public final String getMessage() {
         return message;
@@ -269,5 +276,13 @@ class Error {
 
     public final void setMessage(final String message) {
         this.message = message;
+    }
+
+    public List<OffendingRule> getRules() {
+        return rules;
+    }
+
+    public void setRules(List<OffendingRule> rules) {
+        this.rules = rules;
     }
 }

--- a/core/src/test/java/com/zaubersoftware/gnip4j/api/support/http/ErrorsTest.java
+++ b/core/src/test/java/com/zaubersoftware/gnip4j/api/support/http/ErrorsTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2011-2012 Zauber S.A. <http://www.zaubersoftware.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.support.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.io.IOUtils;
+import org.codehaus.jackson.JsonParseException;
+import org.codehaus.jackson.map.JsonMappingException;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Test;
+
+import com.zaubersoftware.gnip4j.api.exception.OffendingRule;
+
+/**
+ * Unit test to check the {@link Errors} parse from js files with the json response from the server. The idea
+ * is to check that both v1 and v2 response of powertrack are correctly parsed to have backwards
+ * compatibility.
+ *
+ * @author Marcelo
+ */
+public class ErrorsTest {
+    private static final ObjectMapper m = new ObjectMapper();
+
+    @Test
+    public final void test_v1() throws JsonParseException, JsonMappingException, IOException {
+        final Errors errors = m.readValue(ExampleFileDirectory.POWERTRACK_RULE_ERROR_V1.asString(), Errors.class);
+        assertNotNull(errors);
+        assertNotNull(errors.getError());
+        assertEquals(
+                "Rule '-rule1' is invalid.  Rules must contain a non-negation term (at position 1)\nRules must contain at least one positive, non-stopword clause (at position 1)\nRule '-rule14' is invalid.  Rules must contain a non-negation term (at position 1)\nRules must contain at least one positive, non-stopword clause (at position 1)\n",
+                errors.getError().getMessage());
+        assertNull(errors.getError().getRules());
+    }
+
+    @Test
+    public final void test_v2() throws JsonParseException, JsonMappingException, IOException {
+        final Errors errors = m.readValue(ExampleFileDirectory.POWERTRACK_RULE_ERROR_V2.asString(), Errors.class);
+        assertNotNull(errors);
+        assertNotNull(errors.getError());
+        assertEquals("One or more rules are invalid", errors.getError().getMessage());
+        final List<OffendingRule> rules = errors.getError().getRules();
+        assertNotNull(rules);
+        assertEquals(2, rules.size());
+        OffendingRule offendingRule = rules.get(0);
+        assertEquals(
+                "Rules must contain a non-negation term (at position 1)\nRules must contain at least one positive, non-stopword clause (at position 1)\n",
+                offendingRule.getErrorMessage());
+        assertEquals("-rule1", offendingRule.getOffendingRule().getValue());
+        assertNull(offendingRule.getOffendingRule().getTag());
+        offendingRule = rules.get(1);
+        assertEquals(
+                "Rules must contain a non-negation term (at position 1)\nRules must contain at least one positive, non-stopword clause (at position 1)\n",
+                offendingRule.getErrorMessage());
+        assertEquals("-rule14", offendingRule.getOffendingRule().getValue());
+        assertNull(offendingRule.getOffendingRule().getTag());
+    }
+
+    enum ExampleFileDirectory {
+        POWERTRACK_RULE_ERROR_V1("/com/zaubersoftware/gnip4j/powertrack/powertrack_rule_error_v1.js"), POWERTRACK_RULE_ERROR_V2(
+                "/com/zaubersoftware/gnip4j/powertrack/powertrack_rule_error_v2.js"), ;
+
+        private static final String FILES_ENCODING = "utf-8";
+        private final String filePath;
+
+        // caches used to read once
+        private String fullContentCache;
+        private List<String> linesCache;
+
+        private ExampleFileDirectory(final String filePath) {
+            this.filePath = Objects.requireNonNull(filePath);
+        }
+
+        /** @return the file content as a String */
+        public String asString() throws IOException {
+            if (fullContentCache == null) {
+                Reader stream = null;
+                try {
+                    stream = getStream();
+                    fullContentCache = IOUtils.toString(stream);
+                } catch (final IOException e) {
+                    IOUtils.closeQuietly(stream);
+                    throw e;
+                }
+            }
+            return fullContentCache;
+        }
+
+        /**
+         * @return the file content tokenized by line
+         * @throws IOException
+         */
+        public List<String> asLines() throws IOException {
+            if (linesCache == null) {
+                Reader stream = null;
+                try {
+                    stream = getStream();
+                    linesCache = IOUtils.readLines(stream);
+                } catch (final IOException e) {
+                    IOUtils.closeQuietly(stream);
+                    throw e;
+                }
+            }
+            return linesCache;
+        }
+
+        private InputStreamReader getStream() throws UnsupportedEncodingException {
+            return new InputStreamReader(getClass().getResourceAsStream(filePath), FILES_ENCODING);
+        }
+    }
+
+}

--- a/core/src/test/resources/com/zaubersoftware/gnip4j/powertrack/powertrack_rule_error_v1.js
+++ b/core/src/test/resources/com/zaubersoftware/gnip4j/powertrack/powertrack_rule_error_v1.js
@@ -1,0 +1,6 @@
+{
+    "error": {
+        "message": "Rule '-rule1' is invalid.  Rules must contain a non-negation term (at position 1)\nRules must contain at least one positive, non-stopword clause (at position 1)\nRule '-rule14' is invalid.  Rules must contain a non-negation term (at position 1)\nRules must contain at least one positive, non-stopword clause (at position 1)\n",
+        "sent": "2016-01-25T18:38:19+00:00"
+    }
+}

--- a/core/src/test/resources/com/zaubersoftware/gnip4j/powertrack/powertrack_rule_error_v2.js
+++ b/core/src/test/resources/com/zaubersoftware/gnip4j/powertrack/powertrack_rule_error_v2.js
@@ -1,0 +1,17 @@
+{
+    "error": {
+        "detail": [{
+            "rule": {
+                "value": "-rule1"
+            },
+            "message": "Rules must contain a non-negation term (at position 1)\nRules must contain at least one positive, non-stopword clause (at position 1)\n"
+        }, {
+            "rule": {
+                "value": "-rule14"
+            },
+            "message": "Rules must contain a non-negation term (at position 1)\nRules must contain at least one positive, non-stopword clause (at position 1)\n"
+        }],
+        "message": "One or more rules are invalid",
+        "sent": "2016-01-25T18:38:33.634Z"
+    }
+}


### PR DESCRIPTION
To obtain the offending rules in the v2 api directly, but it still can work in v1