### PR TITLE
Handle empty response body from Gnip for non-200 response statuses

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/JRERemoteResourceProvider.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/support/http/JRERemoteResourceProvider.java
@@ -209,6 +209,9 @@ public class JRERemoteResourceProvider extends AbstractRemoteResourceProvider {
     }
     
     static final String toInputStream(final InputStream is) {
+    	if (is == null){
+    		return "";
+    	}
         try {
             final ByteArrayOutputStream bos = new ByteArrayOutputStream();
             byte []buff = new byte[4096];


### PR DESCRIPTION
Cases where gnip returns 503/ non-200 status code but does not include any response body were throwing NullPointerException when trying to get InputStream. Fix is to test for null and return empty string if no response sent.