### PR TITLE
Adding expanded_status field to the Url data model.

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Url.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Url.java
@@ -34,6 +34,9 @@ public class Url implements Serializable {
     @JsonProperty(value = "expanded_url")
     private String expandedUrl;
 
+    @JsonProperty(value = "expanded_status")
+    private Integer expandedStatus;
+
     public final String getUrl() {
         return url;
     }
@@ -49,4 +52,13 @@ public class Url implements Serializable {
     public final void setExpandedUrl(final String expandedUrl) {
         this.expandedUrl = expandedUrl;
     }
+
+    public Integer getExpandedStatus() {
+        return expandedStatus;
+    }
+
+    public void setExpandedStatus(final Integer expandedStatus) {
+        this.expandedStatus = expandedStatus;
+    }
+
 }


### PR DESCRIPTION
Gnip includes the HTTP status of requests to expand URLs. It would be helpful to have this status included in gnip4j's Activity model.
