### PR TITLE
Compliance v2

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/ComplianceV2UriStrategy.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/ComplianceV2UriStrategy.java
@@ -5,7 +5,7 @@ import com.zaubersoftware.gnip4j.api.UriStrategy;
 import java.net.URI;
 
 public class ComplianceV2UriStrategy implements UriStrategy {
-    public static final String BASE_GNIP_STREAM_URI_V2 = "https://gnip-api.twitter.com/stream/compliance/accounts/%s/publishers/twitter/%s.json?partition=%s";
+    public static final String BASE_GNIP_STREAM_URI_V2 = "https://gnip-stream.twitter.com/stream/compliance/accounts/%s/publishers/twitter/%s.json?partition=%s";
 
     private final String baseGnipStreamUri;
     private final String partition;
@@ -56,5 +56,9 @@ public class ComplianceV2UriStrategy implements UriStrategy {
         }
 
         return String.format(BASE_GNIP_RULES_URI, account.trim(), streamName.trim());
+    }
+
+    public String getPartition() {
+        return partition;
     }
 }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/ComplianceV2UriStrategy.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/ComplianceV2UriStrategy.java
@@ -1,0 +1,60 @@
+package com.zaubersoftware.gnip4j.api.impl;
+
+import com.zaubersoftware.gnip4j.api.UriStrategy;
+
+import java.net.URI;
+
+public class ComplianceV2UriStrategy implements UriStrategy {
+    public static final String BASE_GNIP_STREAM_URI_V2 = "https://gnip-api.twitter.com/stream/compliance/accounts/%s/publishers/twitter/%s.json?partition=%s";
+
+    private final String baseGnipStreamUri;
+    private final String partition;
+
+    public static final String BASE_GNIP_RULES_URI = "https://gnip-api.twitter.com/rules/powertrack/accounts/%s/publishers/twitter/%s.json";
+
+    public ComplianceV2UriStrategy(final int partition) {
+        if (partition < 1 || partition > 8) {
+            throw new IllegalArgumentException("Partition must be between 1 and 8 for compliance version 2");
+        } else {
+            this.baseGnipStreamUri = BASE_GNIP_STREAM_URI_V2;
+            this.partition = Integer.toString(partition);
+        }
+    }
+
+    @Override
+    public URI createStreamUri(String account, String streamName) {
+        if (account == null || account.trim().isEmpty()) {
+            throw new IllegalArgumentException("The account cannot be null or empty");
+        }
+        if (streamName == null || streamName.trim().isEmpty()) {
+            throw new IllegalArgumentException("The streamName cannot be null or empty");
+        }
+        return URI.create(String.format(baseGnipStreamUri, account.trim(), streamName.trim(), partition));
+    }
+
+    @Override
+    public URI createRulesUri(final String account, final String streamName) {
+        return URI.create(createRulesBaseUrl(account, streamName));
+    }
+
+    @Override
+    public URI createRulesDeleteUri(final String account, final String streamName) {
+        return URI.create(createRulesBaseUrl(account, streamName) + "?_method=delete");
+    }
+
+    @Override
+    public String getHttpMethodForRulesDelete() {
+        return UriStrategy.HTTP_POST;
+    }
+
+    private String createRulesBaseUrl(final String account, final String streamName) {
+        if (account == null || account.trim().isEmpty()) {
+            throw new IllegalArgumentException("The account cannot be null or empty");
+        }
+        if (streamName == null || streamName.trim().isEmpty()) {
+            throw new IllegalArgumentException("The streamName cannot be null or empty");
+        }
+
+        return String.format(BASE_GNIP_RULES_URI, account.trim(), streamName.trim());
+    }
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/DefaultGnipFacade.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/DefaultGnipFacade.java
@@ -164,7 +164,11 @@ public class DefaultGnipFacade implements GnipFacade {
             ret = new GnipStream() {
                 @Override
                 public String getStreamName() {
-                    return stream.getStreamName();
+                    if(baseUriStrategy instanceof ComplianceV2UriStrategy) {
+                        return stream.getStreamName() + ((ComplianceV2UriStrategy)baseUriStrategy).getPartition();
+                    } else {
+                        return stream.getStreamName();
+                    }
                 }
 
                 @Override
@@ -191,7 +195,7 @@ public class DefaultGnipFacade implements GnipFacade {
                     return stream.getStreamStats();
                 }
             };
-            JMXProvider.getProvider().registerBean(stream, stream.getStreamStats());
+            JMXProvider.getProvider().registerBean(ret, stream.getStreamStats());
         }
         return ret;
     }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/ComplianceActivityUnmarshaller.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/ComplianceActivityUnmarshaller.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2011-2016 Zauber S.A. <http://flowics.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.impl.formats;
+
+import com.zaubersoftware.gnip4j.api.model.Activity;
+import com.zaubersoftware.gnip4j.api.model.compliance.ComplianceActivity;
+import com.zaubersoftware.gnip4j.api.support.logging.LoggerFactory;
+import com.zaubersoftware.gnip4j.api.support.logging.spi.Logger;
+import org.codehaus.jackson.map.JsonMappingException;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.IOException;
+
+/**
+ * Translates JSON input from the Compliance v2 stream into instances of Activity.
+ *
+ * @see <a href="http://support.gnip.com/sources/twitter/data_format.html#SamplePayloads">Sample Payloads</a>
+ *
+ * @author Dennis Lloyd Jr
+ * @since Oct 14, 2016
+ */
+public class ComplianceActivityUnmarshaller implements Unmarshaller<Activity> {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final ObjectMapper mapper = JsonActivityFeedProcessor.getObjectMapper();
+
+    @Override
+    public final Activity unmarshall(final String s) {
+        try {
+            return mapper.readValue(s, ComplianceActivity.class).toActivity();
+        } catch (final JsonMappingException e) {
+            logger.warn("Failed to parse compliance activity: " + s, e);
+            return null;
+        } catch (final IOException e) {
+            throw new IllegalArgumentException("parsing compliance activity", e);
+        }
+    }
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Activity.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Activity.java
@@ -16,9 +16,7 @@
 package com.zaubersoftware.gnip4j.api.model;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 import org.codehaus.jackson.annotate.JsonAutoDetect;
 import org.codehaus.jackson.annotate.JsonProperty;
@@ -72,7 +70,8 @@ public class Activity implements Serializable {
     int [] displayTextRange;
     @JsonProperty(value = "long_object")
     Object longObject;
-    
+    private Collection<String> withheldInCountries;
+
     public final InReplyTo getInReplyTo() {
         return inReplyTo;
     }
@@ -230,7 +229,15 @@ public class Activity implements Serializable {
     public Object getLongObject() {
         return longObject;
     }
-    
+
+    public Collection<String> getWithheldInCountries() {
+        return withheldInCountries;
+    }
+
+    public void setWithheldInCountries(final Collection<String> withheldInCountries) {
+        this.withheldInCountries = withheldInCountries;
+    }
+
     /**
      * https://dev.twitter.com/overview/api/places representation for gnip.
      */

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/ComplianceActivity.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/ComplianceActivity.java
@@ -34,8 +34,10 @@ import java.io.Serializable;
     @JsonSubTypes.Type(value=UndeleteUserActivity.class, name=ComplianceActivity.Verb.USER_UNDELETE),
     @JsonSubTypes.Type(value=ScrubGeoActivity.class, name=ComplianceActivity.Verb.SCRUB_GEO),
     @JsonSubTypes.Type(value=UserProtectActivity.class, name=ComplianceActivity.Verb.USER_PROTECT),
+    @JsonSubTypes.Type(value=UserUnprotectActivity.class, name=ComplianceActivity.Verb.USER_UNPROTECT),
     @JsonSubTypes.Type(value=UserSuspendActivity.class, name=ComplianceActivity.Verb.USER_SUSPEND),
-    @JsonSubTypes.Type(value=UserUnsuspendActivity.class, name=ComplianceActivity.Verb.USER_UNSUSPEND)
+    @JsonSubTypes.Type(value=UserUnsuspendActivity.class, name=ComplianceActivity.Verb.USER_UNSUSPEND),
+    @JsonSubTypes.Type(value=StatusWithheldActivity.class, name=ComplianceActivity.Verb.STATUS_WITHHELD)
 })
 public interface ComplianceActivity extends Serializable {
     Activity toActivity();
@@ -46,7 +48,9 @@ public interface ComplianceActivity extends Serializable {
         String USER_UNDELETE = "user_undelete";
         String SCRUB_GEO = "scrub_geo";
         String USER_PROTECT = "user_protect";
+        String USER_UNPROTECT = "user_unprotect";
         String USER_SUSPEND = "user_suspend";
         String USER_UNSUSPEND = "user_unsuspend";
+        String STATUS_WITHHELD = "status_withheld";
     }
 }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/ComplianceActivity.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/ComplianceActivity.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2011-2016 Zauber S.A. <http://flowics.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.model.compliance;
+
+import com.zaubersoftware.gnip4j.api.model.Activity;
+import org.codehaus.jackson.annotate.JsonSubTypes;
+import org.codehaus.jackson.annotate.JsonTypeInfo;
+
+import java.io.Serializable;
+
+/**
+ * Activity from the Compliance v2 stream that can be converted to an Activity
+ *
+ * @author Dennis Lloyd Jr
+ * @since Oct 14, 2016
+ */
+@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.WRAPPER_OBJECT)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value=DeleteStatusActivity.class, name=ComplianceActivity.Verb.DELETE),
+    @JsonSubTypes.Type(value=DeleteUserActivity.class, name=ComplianceActivity.Verb.USER_DELETE),
+    @JsonSubTypes.Type(value=UndeleteUserActivity.class, name=ComplianceActivity.Verb.USER_UNDELETE),
+    @JsonSubTypes.Type(value=ScrubGeoActivity.class, name=ComplianceActivity.Verb.SCRUB_GEO),
+    @JsonSubTypes.Type(value=UserProtectActivity.class, name=ComplianceActivity.Verb.USER_PROTECT),
+    @JsonSubTypes.Type(value=UserSuspendActivity.class, name=ComplianceActivity.Verb.USER_SUSPEND),
+    @JsonSubTypes.Type(value=UserUnsuspendActivity.class, name=ComplianceActivity.Verb.USER_UNSUSPEND)
+})
+public interface ComplianceActivity extends Serializable {
+    Activity toActivity();
+
+    interface Verb {
+        String DELETE = "delete";
+        String USER_DELETE = "user_delete";
+        String USER_UNDELETE = "user_undelete";
+        String SCRUB_GEO = "scrub_geo";
+        String USER_PROTECT = "user_protect";
+        String USER_SUSPEND = "user_suspend";
+        String USER_UNSUSPEND = "user_unsuspend";
+    }
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/DeleteStatusActivity.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/DeleteStatusActivity.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2011-2016 Zauber S.A. <http://flowics.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.model.compliance;
+
+import com.zaubersoftware.gnip4j.api.model.Activity;
+import com.zaubersoftware.gnip4j.api.model.Actor;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonTypeName;
+
+import java.util.Date;
+
+/**
+ * Represents deleting a status from the Compliance v2 stream
+ *
+ * @author Dennis Lloyd Jr
+ * @since Oct 14, 2016
+ */
+@JsonTypeName(ComplianceActivity.Verb.DELETE)
+class DeleteStatusActivity implements ComplianceActivity {
+    @JsonProperty("status")
+    private Status status;
+    @JsonProperty("timestamp_ms")
+    private String timestamp;
+
+    public static class Status {
+        @JsonProperty("id")
+        private String id;
+        @JsonProperty("user_id")
+        private String userId;
+    }
+
+    @Override
+    public Activity toActivity() {
+        final Activity result = new Activity();
+        result.setVerb(ComplianceActivity.Verb.DELETE);
+        result.setId(status.id);
+        result.setActor(new Actor());
+        result.getActor().setId(status.userId);
+        result.setUpdated(new Date(Long.parseLong(timestamp)));
+        return result;
+    }
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/DeleteUserActivity.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/DeleteUserActivity.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2011-2016 Zauber S.A. <http://flowics.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.model.compliance;
+
+import com.zaubersoftware.gnip4j.api.model.Activity;
+import com.zaubersoftware.gnip4j.api.model.Actor;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonTypeName;
+
+import java.util.Date;
+
+/**
+ * Represents deleting a user from the Compliance v2 stream
+ *
+ * @author Dennis Lloyd Jr
+ * @since Oct 14, 2016
+ */
+@JsonTypeName(ComplianceActivity.Verb.USER_DELETE)
+class DeleteUserActivity implements ComplianceActivity {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("timestamp_ms")
+    private String timestamp;
+
+    @Override
+    public Activity toActivity() {
+        final Activity result = new Activity();
+        result.setVerb(ComplianceActivity.Verb.USER_DELETE);
+        result.setActor(new Actor());
+        result.getActor().setId(id);
+        result.setUpdated(new Date(Long.parseLong(timestamp)));
+        return result;
+    }
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/ScrubGeoActivity.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/ScrubGeoActivity.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2011-2016 Zauber S.A. <http://flowics.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.model.compliance;
+
+import com.zaubersoftware.gnip4j.api.model.Activity;
+import com.zaubersoftware.gnip4j.api.model.Actor;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonTypeName;
+
+import java.util.Date;
+
+/**
+ * Represents a user removing a Geo location in the Compliance v2 stream
+ *
+ * @author Dennis Lloyd Jr
+ * @since Oct 14, 2016
+ */
+@JsonTypeName(ComplianceActivity.Verb.SCRUB_GEO)
+class ScrubGeoActivity implements ComplianceActivity {
+    @JsonProperty("up_to_status_id")
+    private String id;
+    @JsonProperty("user_id")
+    private String userId;
+    @JsonProperty("timestamp_ms")
+    private String timestamp;
+
+    @Override
+    public Activity toActivity() {
+        final Activity result = new Activity();
+        result.setVerb(ComplianceActivity.Verb.SCRUB_GEO);
+        result.setId(id);
+        result.setActor(new Actor());
+        result.getActor().setId(userId);
+        result.setUpdated(new Date(Long.parseLong(timestamp)));
+        return result;
+    }
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/StatusWithheldActivity.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/StatusWithheldActivity.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2011-2016 Zauber S.A. <http://flowics.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.model.compliance;
+
+import com.zaubersoftware.gnip4j.api.model.Activity;
+import com.zaubersoftware.gnip4j.api.model.Actor;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonTypeName;
+
+import java.util.Collection;
+import java.util.Date;
+
+/**
+ * Represents a status being withheld in the Compliance v2 Stream
+ *
+ * @author Dennis Lloyd Jr
+ * @since Oct 14, 2016
+ */
+@JsonTypeName(ComplianceActivity.Verb.USER_UNPROTECT)
+class StatusWithheldActivity implements ComplianceActivity {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("user_id")
+    private String userId;
+
+    @JsonProperty("withheld_in_countries")
+    private Collection<String> withheldInCountries;
+
+    @JsonProperty("timestamp_ms")
+    private String timestamp;
+
+    @Override
+    public Activity toActivity() {
+        final Activity result = new Activity();
+        result.setVerb(ComplianceActivity.Verb.STATUS_WITHHELD);
+        result.setId(id);
+        result.setActor(new Actor());
+        result.getActor().setId(userId);
+        result.setWithheldInCountries(withheldInCountries);
+        result.setUpdated(new Date(Long.parseLong(timestamp)));
+        return result;
+    }
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/UndeleteUserActivity.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/UndeleteUserActivity.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2011-2016 Zauber S.A. <http://flowics.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.model.compliance;
+
+import com.zaubersoftware.gnip4j.api.model.Activity;
+import com.zaubersoftware.gnip4j.api.model.Actor;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonTypeName;
+
+import java.util.Date;
+
+/**
+ * Represents undoing a user delete from the Compliance v2 stream
+ *
+ * @author Dennis Lloyd Jr
+ * @since Oct 14, 2016
+ */
+@JsonTypeName(ComplianceActivity.Verb.USER_UNDELETE)
+class UndeleteUserActivity implements ComplianceActivity {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("timestamp_ms")
+    private String timestamp;
+
+    @Override
+    public Activity toActivity() {
+        final Activity result = new Activity();
+        result.setVerb(ComplianceActivity.Verb.USER_UNDELETE);
+        result.setActor(new Actor());
+        result.getActor().setId(id);
+        result.setUpdated(new Date(Long.parseLong(timestamp)));
+        return result;
+    }
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/UserProtectActivity.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/UserProtectActivity.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2011-2016 Zauber S.A. <http://flowics.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.model.compliance;
+
+import com.zaubersoftware.gnip4j.api.model.Activity;
+import com.zaubersoftware.gnip4j.api.model.Actor;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonTypeName;
+
+import java.util.Date;
+
+/**
+ * Represents a user becoming 'protected' - only visible to their followers in the Compliance v2 Stream
+ *
+ * @author Dennis Lloyd Jr
+ * @since Oct 14, 2016
+ */
+@JsonTypeName(ComplianceActivity.Verb.USER_PROTECT)
+class UserProtectActivity implements ComplianceActivity {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("timestamp_ms")
+    private String timestamp;
+
+    @Override
+    public Activity toActivity() {
+        final Activity result = new Activity();
+        result.setVerb(ComplianceActivity.Verb.USER_PROTECT);
+        result.setActor(new Actor());
+        result.getActor().setId(id);
+        result.setUpdated(new Date(Long.parseLong(timestamp)));
+        return result;
+    }
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/UserSuspendActivity.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/UserSuspendActivity.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2011-2016 Zauber S.A. <http://flowics.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.model.compliance;
+
+import com.zaubersoftware.gnip4j.api.model.Activity;
+import com.zaubersoftware.gnip4j.api.model.Actor;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonTypeName;
+
+import java.util.Date;
+
+/**
+ * Represents a user is suspended in the Compliance v2 Stream
+ *
+ * @author Dennis Lloyd Jr
+ * @since Oct 14, 2016
+ */
+@JsonTypeName(ComplianceActivity.Verb.USER_SUSPEND)
+class UserSuspendActivity implements ComplianceActivity {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("timestamp_ms")
+    private String timestamp;
+
+    @Override
+    public Activity toActivity() {
+        final Activity result = new Activity();
+        result.setVerb(ComplianceActivity.Verb.USER_SUSPEND);
+        result.setActor(new Actor());
+        result.getActor().setId(id);
+        result.setUpdated(new Date(Long.parseLong(timestamp)));
+        return result;
+    }
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/UserUnprotectActivity.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/UserUnprotectActivity.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2011-2016 Zauber S.A. <http://flowics.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.model.compliance;
+
+import com.zaubersoftware.gnip4j.api.model.Activity;
+import com.zaubersoftware.gnip4j.api.model.Actor;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonTypeName;
+
+import java.util.Date;
+
+/**
+ * Represents a user becoming 'unprotected' - only visible to their followers in the Compliance v2 Stream
+ *
+ * @author Dennis Lloyd Jr
+ * @since Oct 14, 2016
+ */
+@JsonTypeName(ComplianceActivity.Verb.USER_UNPROTECT)
+class UserUnprotectActivity implements ComplianceActivity {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("timestamp_ms")
+    private String timestamp;
+
+    @Override
+    public Activity toActivity() {
+        final Activity result = new Activity();
+        result.setVerb(ComplianceActivity.Verb.USER_UNPROTECT);
+        result.setActor(new Actor());
+        result.getActor().setId(id);
+        result.setUpdated(new Date(Long.parseLong(timestamp)));
+        return result;
+    }
+}

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/UserUnsuspendActivity.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/UserUnsuspendActivity.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2011-2016 Zauber S.A. <http://flowics.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.model.compliance;
+
+import com.zaubersoftware.gnip4j.api.model.Activity;
+import com.zaubersoftware.gnip4j.api.model.Actor;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonTypeName;
+
+import java.util.Date;
+
+/**
+ * Represents a user is unsuspended in the Compliance v2 Stream
+ *
+ * @author Dennis Lloyd Jr
+ * @since Oct 14, 2016
+ */
+@JsonTypeName(ComplianceActivity.Verb.USER_UNSUSPEND)
+class UserUnsuspendActivity implements ComplianceActivity {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("timestamp_ms")
+    private String timestamp;
+
+    @Override
+    public Activity toActivity() {
+        final Activity result = new Activity();
+        result.setVerb(ComplianceActivity.Verb.USER_UNSUSPEND);
+        result.setActor(new Actor());
+        result.getActor().setId(id);
+        result.setUpdated(new Date(Long.parseLong(timestamp)));
+        return result;
+    }
+}

--- a/core/src/test/java/com/zaubersoftware/gnip4j/api/impl/ComplianceV2UriStrategyTest.java
+++ b/core/src/test/java/com/zaubersoftware/gnip4j/api/impl/ComplianceV2UriStrategyTest.java
@@ -11,7 +11,7 @@ public class ComplianceV2UriStrategyTest {
     public void uriConstructedFromAccountAndStream() {
         ComplianceV2UriStrategy strategy = new ComplianceV2UriStrategy(1);
         URI streamUri = strategy.createStreamUri("my-account", "my-stream");
-        assertEquals("https://gnip-api.twitter.com/stream/compliance/accounts/my-account/publishers/twitter/my-stream.json?partition=1", streamUri.toString());
+        assertEquals("https://gnip-stream.twitter.com/stream/compliance/accounts/my-account/publishers/twitter/my-stream.json?partition=1", streamUri.toString());
 
         URI rulesUri = strategy.createRulesUri("my-account", "my-stream");
         assertEquals("https://gnip-api.twitter.com/rules/powertrack/accounts/my-account/publishers/twitter/my-stream.json", rulesUri.toString());

--- a/core/src/test/java/com/zaubersoftware/gnip4j/api/impl/ComplianceV2UriStrategyTest.java
+++ b/core/src/test/java/com/zaubersoftware/gnip4j/api/impl/ComplianceV2UriStrategyTest.java
@@ -1,0 +1,39 @@
+package com.zaubersoftware.gnip4j.api.impl;
+
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.junit.Assert.*;
+
+public class ComplianceV2UriStrategyTest {
+    @Test
+    public void uriConstructedFromAccountAndStream() {
+        ComplianceV2UriStrategy strategy = new ComplianceV2UriStrategy(1);
+        URI streamUri = strategy.createStreamUri("my-account", "my-stream");
+        assertEquals("https://gnip-api.twitter.com/stream/compliance/accounts/my-account/publishers/twitter/my-stream.json?partition=1", streamUri.toString());
+
+        URI rulesUri = strategy.createRulesUri("my-account", "my-stream");
+        assertEquals("https://gnip-api.twitter.com/rules/powertrack/accounts/my-account/publishers/twitter/my-stream.json", rulesUri.toString());
+    }
+
+    @Test
+    public void supportsPartitionsBetweenOneAndEight() {
+        // Allowed
+        for (int partitionNumber = 1; partitionNumber <= 8; partitionNumber++) {
+            ComplianceV2UriStrategy strategy = new ComplianceV2UriStrategy(partitionNumber);
+            final String streamUri = strategy.createStreamUri("my-account", "my-stream").toString();
+            assertEquals(Integer.toString(partitionNumber), streamUri.substring(streamUri.length() - 1, streamUri.length()));
+        }
+
+        // Illegal
+        for (int partitionNumber : new int[]{0, 9, 13}) {
+            try {
+                new ComplianceV2UriStrategy(partitionNumber);
+                fail("Should have thrown IllegalArgumentException for partition: " + partitionNumber);
+            } catch (IllegalArgumentException iae) {
+                // We expect this exception
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/zaubersoftware/gnip4j/api/impl/formats/ComplianceActivityUnmarshallerTest.java
+++ b/core/src/test/java/com/zaubersoftware/gnip4j/api/impl/formats/ComplianceActivityUnmarshallerTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2011-2016 Zauber S.A. <http://flowics.com/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaubersoftware.gnip4j.api.impl.formats;
+
+import com.zaubersoftware.gnip4j.api.model.Activity;
+import com.zaubersoftware.gnip4j.api.model.compliance.ComplianceActivity;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Dennis Lloyd Jr
+ * @since Oct 14, 2016
+ */
+public class ComplianceActivityUnmarshallerTest {
+    Unmarshaller<Activity> unmarshaller;
+
+    @Before
+    public void setup() {
+        unmarshaller = new ComplianceActivityUnmarshaller();
+    }
+
+    @Test
+    public void deleteStatus() {
+        final String s = "{\"delete\":{\"status\":{\"id\":601430178305220600,\"id_str\":\"601430178305220600\",\"user_id\":3198576760,\"user_id_str\":\"3198576760\"},\"timestamp_ms\":\"1432228155593\"}}";
+        final Activity result = unmarshaller.unmarshall(s);
+        assertEquals(ComplianceActivity.Verb.DELETE, result.getVerb());
+        assertEquals("601430178305220600", result.getId());
+        assertEquals("3198576760", result.getActor().getId());
+        assertEquals(new Date(1432228155593L), result.getUpdated());
+    }
+
+    @Test
+    public void deleteUser() {
+        final String s = "{\"user_delete\":{\"id\":771136850,\"timestamp_ms\":\"1432228153548\"}}";
+        final Activity result = unmarshaller.unmarshall(s);
+        assertEquals(ComplianceActivity.Verb.USER_DELETE, result.getVerb());
+        assertEquals("771136850", result.getActor().getId());
+        assertEquals(new Date(1432228153548L), result.getUpdated());
+    }
+
+    @Test
+    public void undeleteUser() {
+        final String s = "{\"user_undelete\":{\"id\":796250066,\"timestamp_ms\":\"1432228149062\"}}";
+        final Activity result = unmarshaller.unmarshall(s);
+        assertEquals(ComplianceActivity.Verb.USER_UNDELETE, result.getVerb());
+        assertEquals("796250066", result.getActor().getId());
+        assertEquals(new Date(1432228149062L), result.getUpdated());
+    }
+    
+    @Test
+    public void scrubGeo() {
+        final String s = "{\"scrub_geo\":{\"user_id\":519761961,\"up_to_status_id\":411552403083628540,\"up_to_status_id_str\":\"411552403083628544\",\"user_id_str\":\"519761961\",\"timestamp_ms\":\"1432228180345\"}}";
+        final Activity result = unmarshaller.unmarshall(s);
+        assertEquals(ComplianceActivity.Verb.SCRUB_GEO, result.getVerb());
+        assertEquals("411552403083628540", result.getId());
+        assertEquals("519761961", result.getActor().getId());
+        assertEquals(new Date(1432228180345L), result.getUpdated());
+    }
+
+    @Test
+    public void userProtect() {
+        final String s = "{\"user_protect\":{\"id\":3182003550,\"timestamp_ms\":\"1432228177137\"}}";
+        final Activity result = unmarshaller.unmarshall(s);
+        assertEquals(ComplianceActivity.Verb.USER_PROTECT, result.getVerb());
+        assertEquals("3182003550", result.getActor().getId());
+        assertEquals(new Date(1432228177137L), result.getUpdated());
+    }
+
+    @Test
+    public void userSuspend() {
+        final String s = "{\"user_suspend\":{\"id\":3120539094,\"timestamp_ms\":\"1432228194217\"}}";
+        final Activity result = unmarshaller.unmarshall(s);
+        assertEquals(ComplianceActivity.Verb.USER_SUSPEND, result.getVerb());
+        assertEquals("3120539094", result.getActor().getId());
+        assertEquals(new Date(1432228194217L), result.getUpdated());
+    }
+
+    @Test
+    public void userUnsuspend() {
+        final String s = "{\"user_unsuspend\":{\"id\":3293130873,\"timestamp_ms\":\"1432228193828\"}}";
+        final Activity result = unmarshaller.unmarshall(s);
+        assertEquals(ComplianceActivity.Verb.USER_UNSUSPEND, result.getVerb());
+        assertEquals("3293130873", result.getActor().getId());
+        assertEquals(new Date(1432228193828L), result.getUpdated());
+    }
+
+    @Test
+    public void unrecognizedMesssageType() {
+        final String s = "{\"unknown\":{\"id\":3293130873,\"timestamp_ms\":\"1432228193828\"}}";
+        assertNull(unmarshaller.unmarshall(s));
+    }
+}

--- a/core/src/test/java/com/zaubersoftware/gnip4j/api/impl/formats/ComplianceActivityUnmarshallerTest.java
+++ b/core/src/test/java/com/zaubersoftware/gnip4j/api/impl/formats/ComplianceActivityUnmarshallerTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (c) 2011-2016 Zauber S.A. <http://flowics.com/>
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,7 @@ import com.zaubersoftware.gnip4j.api.model.compliance.ComplianceActivity;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
@@ -64,7 +65,7 @@ public class ComplianceActivityUnmarshallerTest {
         assertEquals("796250066", result.getActor().getId());
         assertEquals(new Date(1432228149062L), result.getUpdated());
     }
-    
+
     @Test
     public void scrubGeo() {
         final String s = "{\"scrub_geo\":{\"user_id\":519761961,\"up_to_status_id\":411552403083628540,\"up_to_status_id_str\":\"411552403083628544\",\"user_id_str\":\"519761961\",\"timestamp_ms\":\"1432228180345\"}}";
@@ -85,6 +86,15 @@ public class ComplianceActivityUnmarshallerTest {
     }
 
     @Test
+    public void userUnprotect() {
+        final String s = "{\"user_unprotect\":{\"id\":2911076065,\"timestamp_ms\":\"1432228180113\"}}";
+        final Activity result = unmarshaller.unmarshall(s);
+        assertEquals(ComplianceActivity.Verb.USER_UNPROTECT, result.getVerb());
+        assertEquals("2911076065", result.getActor().getId());
+        assertEquals(new Date(1432228180113L), result.getUpdated());
+    }
+
+    @Test
     public void userSuspend() {
         final String s = "{\"user_suspend\":{\"id\":3120539094,\"timestamp_ms\":\"1432228194217\"}}";
         final Activity result = unmarshaller.unmarshall(s);
@@ -100,6 +110,17 @@ public class ComplianceActivityUnmarshallerTest {
         assertEquals(ComplianceActivity.Verb.USER_UNSUSPEND, result.getVerb());
         assertEquals("3293130873", result.getActor().getId());
         assertEquals(new Date(1432228193828L), result.getUpdated());
+    }
+
+    @Test
+    public void statusWithheld() {
+        final String s = "{\"status_withheld\":{\"id\":787218718879342592,\"user_id\":2308560145,\"withheld_in_countries\":[\"xy\"],\"timestamp_ms\":\"1476731813446\"}}";
+        final Activity result = unmarshaller.unmarshall(s);
+        assertEquals(ComplianceActivity.Verb.STATUS_WITHHELD, result.getVerb());
+        assertEquals("787218718879342592", result.getId());
+        assertEquals("2308560145", result.getActor().getId());
+        assertEquals(Arrays.asList("xy"), result.getWithheldInCountries());
+        assertEquals(new Date(1476731813446L), result.getUpdated());
     }
 
     @Test


### PR DESCRIPTION
Provides support for Twitter's v2 Compliance Stream. The following has been done:
1. Add a ComplianceActivityUnmarshaller and related ComplianceActivity classes which read input from the compliance stream and translate them into standard Activity objects.
2. Add a ComplianceV2UriStrategy for connecting to the compliance stream.
3. Handle the fact that the compliance stream is split across 8 different partitions when creating the stream name for the JMX reporting.