### PR TITLE
Upgrade mockito from 2.0.2-beta to 2.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,12 +87,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>2.0.2-beta</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>2.0.2-beta</version>
+        <version>2.2.5</version>
       </dependency>
       <!-- END: Testing -->
       <dependency>


### PR DESCRIPTION
Not sure why this upgrade was skipped when releasing gnip4j 2.x

Also, `mockito-all` is a relic and is not needed when using Maven