### PR TITLE
Extend activity mapping

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Url.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/Url.java
@@ -37,6 +37,12 @@ public class Url implements Serializable {
     @JsonProperty(value = "expanded_status")
     private Integer expandedStatus;
 
+    @JsonProperty(value = "expanded_url_title")
+    private String expandedUrlTitle;
+
+    @JsonProperty(value = "expanded_url_description")
+    private String expandedUrlDescription;
+
     public final String getUrl() {
         return url;
     }
@@ -61,4 +67,19 @@ public class Url implements Serializable {
         this.expandedStatus = expandedStatus;
     }
 
+    public String getExpandedUrlTitle() {
+        return expandedUrlTitle;
+    }
+
+    public void setExpandedUrlTitle(String expandedUrlTitle) {
+        this.expandedUrlTitle = expandedUrlTitle;
+    }
+
+    public String getExpandedUrlDescription() {
+        return expandedUrlDescription;
+    }
+
+    public void setExpandedUrlDescription(String expandedUrlDescription) {
+        this.expandedUrlDescription = expandedUrlDescription;
+    }
 }

--- a/core/src/test/java/com/zaubersoftware/gnip4j/api/model/UrlDeserializerTest.java
+++ b/core/src/test/java/com/zaubersoftware/gnip4j/api/model/UrlDeserializerTest.java
@@ -1,0 +1,37 @@
+package com.zaubersoftware.gnip4j.api.model;
+
+import com.zaubersoftware.gnip4j.api.impl.formats.JsonActivityFeedProcessor;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Fredrik Olsson
+ */
+public class UrlDeserializerTest {
+    private static final ObjectMapper mapper = JsonActivityFeedProcessor.getObjectMapper();
+
+    @Test
+    public void testUrl() throws Exception {
+
+        // Test data taken from Gnip PowerTrack v2 documentation at:
+        // http://support.gnip.com/apis/powertrack2.0/transition.html#Payload
+
+        String urlJson = "{\n" +
+                "\"url\": \"https:\\/\\/t.co\\/b9ZdzRxzFK\",\n" +
+                "\"expanded_url\": \"http:\\/\\/www.today.com\\/parents\\/joke-s-you-kid-11-family-friendly-april-fools-pranks-t83276\",\n" +
+                "\"expanded_status\": 200,\n" +
+                "\"expanded_url_title\": \"The joke's on you, kid: 11 family-friendly April Fools pranks\",\n" +
+                "\"expanded_url_description\": \"If your kids are practical jokers, turn this April Fools' Day into a family affair.\"\n" +
+                "}";
+
+        Url url = mapper.readValue(urlJson, Url.class);
+        assertEquals("Original URL", "https://t.co/b9ZdzRxzFK", url.getUrl());
+        assertEquals("Expanded URL", "http://www.today.com/parents/joke-s-you-kid-11-family-friendly-april-fools-pranks-t83276", url.getExpandedUrl());
+        assertEquals("Expanded status", (Integer) 200, url.getExpandedStatus());
+        assertEquals("Expanded URL title", "The joke's on you, kid: 11 family-friendly April Fools pranks", url.getExpandedUrlTitle());
+        assertEquals("Expanded URL description", "If your kids are practical jokers, turn this April Fools' Day into a family affair.", url.getExpandedUrlDescription());
+    }
+
+}


### PR DESCRIPTION
The changes makes additional fields in the gnip.urls.url available in the gnip4j API model, and allows for access to gnip.urls.url.expanded_url_title and gnip.urls.url.expanded_url_description.