### PR TITLE
Add support for delete favorite and user withheld

### DIFF
--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/ComplianceActivityUnmarshaller.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/impl/formats/ComplianceActivityUnmarshaller.java
@@ -15,15 +15,14 @@
  */
 package com.zaubersoftware.gnip4j.api.impl.formats;
 
-import java.io.IOException;
-
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-
 import com.zaubersoftware.gnip4j.api.model.Activity;
 import com.zaubersoftware.gnip4j.api.model.compliance.ComplianceActivity;
 import com.zaubersoftware.gnip4j.api.support.logging.LoggerFactory;
 import com.zaubersoftware.gnip4j.api.support.logging.spi.Logger;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
 
 /**
  * Translates JSON input from the Compliance v2 stream into instances of Activity.
@@ -41,11 +40,9 @@ public class ComplianceActivityUnmarshaller implements Unmarshaller<Activity> {
     public final Activity unmarshall(final String s) {
         try {
             return mapper.readValue(s, ComplianceActivity.class).toActivity();
-        } catch (final JsonMappingException e) {
+        } catch (final IOException | UncheckedIOException e) {
             logger.warn("Failed to parse compliance activity: " + s, e);
             return null;
-        } catch (final IOException e) {
-            throw new IllegalArgumentException("parsing compliance activity", e);
         }
     }
 }

--- a/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/ComplianceActivity.java
+++ b/core/src/main/java/com/zaubersoftware/gnip4j/api/model/compliance/ComplianceActivity.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (c) 2011-2016 Zauber S.A. <http://flowics.com/>
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,12 +15,11 @@
  */
 package com.zaubersoftware.gnip4j.api.model.compliance;
 
-import java.io.Serializable;
-
+import com.zaubersoftware.gnip4j.api.model.Activity;
 import org.codehaus.jackson.annotate.JsonSubTypes;
 import org.codehaus.jackson.annotate.JsonTypeInfo;
 
-import com.zaubersoftware.gnip4j.api.model.Activity;
+import java.io.Serializable;
 
 /**
  * Activity from the Compliance v2 stream that can be converted to an Activity
@@ -28,23 +27,25 @@ import com.zaubersoftware.gnip4j.api.model.Activity;
  * @author Dennis Lloyd Jr
  * @since Oct 14, 2016
  */
-@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.WRAPPER_OBJECT)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonSubTypes({
-    @JsonSubTypes.Type(value=DeleteStatusActivity.class, name=ComplianceActivity.Verb.DELETE),
-    @JsonSubTypes.Type(value=DeleteUserActivity.class, name=ComplianceActivity.Verb.USER_DELETE),
-    @JsonSubTypes.Type(value=UndeleteUserActivity.class, name=ComplianceActivity.Verb.USER_UNDELETE),
-    @JsonSubTypes.Type(value=ScrubGeoActivity.class, name=ComplianceActivity.Verb.SCRUB_GEO),
-    @JsonSubTypes.Type(value=UserProtectActivity.class, name=ComplianceActivity.Verb.USER_PROTECT),
-    @JsonSubTypes.Type(value=UserUnprotectActivity.class, name=ComplianceActivity.Verb.USER_UNPROTECT),
-    @JsonSubTypes.Type(value=UserSuspendActivity.class, name=ComplianceActivity.Verb.USER_SUSPEND),
-    @JsonSubTypes.Type(value=UserUnsuspendActivity.class, name=ComplianceActivity.Verb.USER_UNSUSPEND),
-    @JsonSubTypes.Type(value=StatusWithheldActivity.class, name=ComplianceActivity.Verb.STATUS_WITHHELD)
+    @JsonSubTypes.Type(value = DeleteActivity.class, name = ComplianceActivity.Verb.DELETE),
+    @JsonSubTypes.Type(value = DeleteUserActivity.class, name = ComplianceActivity.Verb.USER_DELETE),
+    @JsonSubTypes.Type(value = UndeleteUserActivity.class, name = ComplianceActivity.Verb.USER_UNDELETE),
+    @JsonSubTypes.Type(value = ScrubGeoActivity.class, name = ComplianceActivity.Verb.SCRUB_GEO),
+    @JsonSubTypes.Type(value = UserProtectActivity.class, name = ComplianceActivity.Verb.USER_PROTECT),
+    @JsonSubTypes.Type(value = UserUnprotectActivity.class, name = ComplianceActivity.Verb.USER_UNPROTECT),
+    @JsonSubTypes.Type(value = UserSuspendActivity.class, name = ComplianceActivity.Verb.USER_SUSPEND),
+    @JsonSubTypes.Type(value = UserUnsuspendActivity.class, name = ComplianceActivity.Verb.USER_UNSUSPEND),
+    @JsonSubTypes.Type(value = StatusWithheldActivity.class, name = ComplianceActivity.Verb.STATUS_WITHHELD),
+    @JsonSubTypes.Type(value = UserWithheldActivity.class, name = ComplianceActivity.Verb.USER_WITHHELD)
 })
 public interface ComplianceActivity extends Serializable {
     Activity toActivity();
 
     interface Verb {
         String DELETE = "delete";
+        String FAVORITE_DELETE = "favorite_delete";
         String USER_DELETE = "user_delete";
         String USER_UNDELETE = "user_undelete";
         String SCRUB_GEO = "scrub_geo";
@@ -53,5 +54,6 @@ public interface ComplianceActivity extends Serializable {
         String USER_SUSPEND = "user_suspend";
         String USER_UNSUSPEND = "user_unsuspend";
         String STATUS_WITHHELD = "status_withheld";
+        String USER_WITHHELD = "user_withheld";
     }
 }

--- a/core/src/test/java/com/zaubersoftware/gnip4j/api/impl/formats/ComplianceActivityUnmarshallerTest.java
+++ b/core/src/test/java/com/zaubersoftware/gnip4j/api/impl/formats/ComplianceActivityUnmarshallerTest.java
@@ -15,16 +15,16 @@
  */
 package com.zaubersoftware.gnip4j.api.impl.formats;
 
-import static org.junit.Assert.*;
+import com.zaubersoftware.gnip4j.api.model.Activity;
+import com.zaubersoftware.gnip4j.api.model.compliance.ComplianceActivity;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Date;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import com.zaubersoftware.gnip4j.api.model.Activity;
-import com.zaubersoftware.gnip4j.api.model.compliance.ComplianceActivity;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Dennis Lloyd Jr
@@ -46,6 +46,23 @@ public class ComplianceActivityUnmarshallerTest {
         assertEquals("601430178305220600", result.getId());
         assertEquals("3198576760", result.getActor().getId());
         assertEquals(new Date(1432228155593L), result.getUpdated());
+    }
+
+    @Test
+    public void deleteFavorite() {
+        final String s = "{\"delete\":{\"favorite\":{\"id\":601430178305220600,\"id_str\":\"601430178305220600\",\"user_id\":3198576760,\"user_id_str\":\"3198576760\"},\"timestamp_ms\":\"1432228155593\"}}";
+        final Activity result = unmarshaller.unmarshall(s);
+        assertEquals(ComplianceActivity.Verb.FAVORITE_DELETE, result.getVerb());
+        assertEquals("601430178305220600", result.getId());
+        assertEquals("3198576760", result.getActor().getId());
+        assertEquals(new Date(1432228155593L), result.getUpdated());
+    }
+
+    @Test
+    public void deleteUnknown() { // What happens when we receive data for a delete that we don't expect
+        final String s = "{\"delete\":{\"unknown\":{\"id\":601430178305220600,\"id_str\":\"601430178305220600\",\"user_id\":3198576760,\"user_id_str\":\"3198576760\"},\"timestamp_ms\":\"1432228155593\"}}";
+        final Activity result = unmarshaller.unmarshall(s);
+        assertNull(result);
     }
 
     @Test
@@ -121,6 +138,16 @@ public class ComplianceActivityUnmarshallerTest {
         assertEquals("2308560145", result.getActor().getId());
         assertEquals(Arrays.asList("xy"), result.getWithheldInCountries());
         assertEquals(new Date(1476731813446L), result.getUpdated());
+    }
+
+    @Test
+    public void userWithheld() {
+        final String s = "{\"user_withheld\":{\"id\":1375036644,\"timestamp_ms\":\"1481626100690\",\"withheld_in_countries\":[\"TR\"]}}";
+        final Activity result = unmarshaller.unmarshall(s);
+        assertEquals(ComplianceActivity.Verb.USER_WITHHELD, result.getVerb());
+        assertEquals("1375036644", result.getActor().getId());
+        assertEquals(Arrays.asList("TR"), result.getWithheldInCountries());
+        assertEquals(new Date(1481626100690L), result.getUpdated());
     }
 
     @Test


### PR DESCRIPTION
Related to issue: https://github.com/zauberlabs/gnip4j/issues/66

When the compliance stream receives a delete favorite event, the following exception is thrown:

```
WARN  [] c.z.g.api.impl.DefaultGnipStream {} - Unexpected exception while consuming activity stream {your-stream-name}: null
[10.100.6.81] out: java.lang.NullPointerException: null
[10.100.6.81] out: 	at com.zaubersoftware.gnip4j.api.model.compliance.DeleteStatusActivity$Status.access$000(DeleteStatusActivity.java:38) ~[gnip4j-core-2.1.0.jar:na]
[10.100.6.81] out: 	at com.zaubersoftware.gnip4j.api.model.compliance.DeleteStatusActivity.toActivity(DeleteStatusActivity.java:49) ~[gnip4j-core-2.1.0.jar:na]
[10.100.6.81] out: 	at com.zaubersoftware.gnip4j.api.impl.formats.ComplianceActivityUnmarshaller.unmarshall(ComplianceActivityUnmarshaller.java:42) ~[gnip4j-core-2.1.0.jar:na]
[10.100.6.81] out: 	at com.zaubersoftware.gnip4j.api.impl.formats.ComplianceActivityUnmarshaller.unmarshall(ComplianceActivityUnmarshaller.java:35) ~[gnip4j-core-2.1.0.jar:na]
[10.100.6.81] out: 	at com.zaubersoftware.gnip4j.api.impl.formats.ByLineFeedProcessor.process(ByLineFeedProcessor.java:53) ~[gnip4j-core-2.1.0.jar:na]
[10.100.6.81] out: 	at com.zaubersoftware.gnip4j.api.impl.DefaultGnipStream$GnipHttpConsumer.run(DefaultGnipStream.java:229) ~[gnip4j-core-2.1.0.jar:na]
[10.100.6.81] out: 	at java.lang.Thread.run(Thread.java:745) [na:1.8.0_72]
```

Because the exception is unexpected, it actually assumes that it is disconnects and immediately tries to reconnect, resulting in some thrashing of the connections.